### PR TITLE
Feat(be): Spring REST docs 적용

### DIFF
--- a/backend/grabtable/.gitignore
+++ b/backend/grabtable/.gitignore
@@ -42,3 +42,6 @@ out/
 
 ### application*.yml ###
 src/main/resources/*.yml
+
+### Spring REST docs ###
+src/main/resources/static/docs/*.html

--- a/backend/grabtable/build.gradle
+++ b/backend/grabtable/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.4'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.asciidoctor.jvm.convert' version "3.3.2"
 }
 
 group = 'edu.skku'
@@ -12,6 +13,7 @@ java {
 }
 
 configurations {
+    asciidoctorExt
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -37,8 +39,39 @@ dependencies {
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //spring rest docs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    baseDirFollowsSourceFile()
+    configurations 'asciidoctorExt'
+    dependsOn test
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
 }

--- a/backend/grabtable/src/docs/asciidoc/index.adoc
+++ b/backend/grabtable/src/docs/asciidoc/index.adoc
@@ -1,0 +1,8 @@
+= Spring REST Docs Test
+:doctype: book
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+
+include::test.adoc[]

--- a/backend/grabtable/src/docs/asciidoc/index.adoc
+++ b/backend/grabtable/src/docs/asciidoc/index.adoc
@@ -5,4 +5,5 @@
 :toclevels: 2
 :seclinks:
 
-include::test.adoc[]
+include::review-controller-test.adoc[]
+include::login-controller-test.adoc[]

--- a/backend/grabtable/src/docs/asciidoc/login-controller-test.adoc
+++ b/backend/grabtable/src/docs/asciidoc/login-controller-test.adoc
@@ -1,0 +1,31 @@
+== LoginController
+
+=== 카카오 소셜 로그인 (POST /v1/auth/login/kakao)
+
+==== 요청
+
+include::{snippets}/login-controller-test/kakao-social-login/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/login-controller-test/kakao-social-login/http-response.adoc[]
+
+=== Access Token 재발급 (POST /v1/auth/reissue)
+
+==== 요청
+
+include::{snippets}/login-controller-test/reissue-token/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/login-controller-test/reissue-token/http-response.adoc[]
+
+=== 로그아웃 (POST /v1/auth/logout)
+
+==== 요청
+
+include::{snippets}/login-controller-test/logout/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/login-controller-test/logout/http-response.adoc[]

--- a/backend/grabtable/src/docs/asciidoc/review-controller-test.adoc
+++ b/backend/grabtable/src/docs/asciidoc/review-controller-test.adoc
@@ -1,6 +1,6 @@
 == ReviewController
 
-=== 유저의 모든 리뷰 조회 (GET /api/v1/reviews/\{userId\})
+=== 유저의 모든 리뷰 조회 (GET /v1/reviews/\{userId\})
 
 ==== 요청
 
@@ -10,7 +10,7 @@ include::{snippets}/review-controller-test/get-all-reviews-by-user-id/http-reque
 
 include::{snippets}/review-controller-test/get-all-reviews-by-user-id/http-response.adoc[]
 
-=== 가게의 모든 리뷰 조회 (GET /api/v1/reviews/\{storeId\})
+=== 가게의 모든 리뷰 조회 (GET /v1/reviews/\{storeId\})
 
 ==== 요청
 
@@ -20,7 +20,7 @@ include::{snippets}/review-controller-test/get-all-reviews-by-store-id/http-requ
 
 include::{snippets}/review-controller-test/get-all-reviews-by-store-id/http-response.adoc[]
 
-=== 리뷰 등록 (POST /api/v1/reviews/\{reviewId\})
+=== 리뷰 등록 (POST /v1/reviews/\{reviewId\})
 
 ==== 요청
 
@@ -30,7 +30,7 @@ include::{snippets}/review-controller-test/upload-review/http-request.adoc[]
 
 include::{snippets}/review-controller-test/upload-review/http-response.adoc[]
 
-=== 리뷰 수정 (PATCH /api/v1/reviews/\{reviewId\})
+=== 리뷰 수정 (PATCH /v1/reviews/\{reviewId\})
 
 ==== 요청
 
@@ -40,7 +40,7 @@ include::{snippets}/review-controller-test/update-review/http-request.adoc[]
 
 include::{snippets}/review-controller-test/update-review/http-response.adoc[]
 
-=== 리뷰 삭제 (DELETE /api/v1/reviews/\{reviewId\})
+=== 리뷰 삭제 (DELETE /v1/reviews/\{reviewId\})
 
 ==== 요청
 

--- a/backend/grabtable/src/docs/asciidoc/test.adoc
+++ b/backend/grabtable/src/docs/asciidoc/test.adoc
@@ -1,0 +1,41 @@
+== ReviewController
+
+=== 유저의 모든 리뷰 조회 (GET /api/v1/reviews/\{userId\})
+
+==== 요청
+
+include::{snippets}/review-controller-test/get-all-reviews-by-user-id/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/review-controller-test/get-all-reviews-by-user-id/http-response.adoc[]
+
+=== 가게의 모든 리뷰 조회 (GET /api/v1/reviews/\{storeId\})
+
+==== 요청
+
+include::{snippets}/review-controller-test/get-all-reviews-by-store-id/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/review-controller-test/get-all-reviews-by-store-id/http-response.adoc[]
+
+=== 리뷰 등록 (POST /api/v1/reviews/\{reviewId\})
+
+==== 요청
+
+include::{snippets}/review-controller-test/upload-review/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/review-controller-test/upload-review/http-response.adoc[]
+
+=== 리뷰 수정 (PATCH /api/v1/reviews/\{reviewId\})
+
+==== 요청
+
+include::{snippets}/review-controller-test/update-review/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/review-controller-test/update-review/http-response.adoc[]

--- a/backend/grabtable/src/docs/asciidoc/test.adoc
+++ b/backend/grabtable/src/docs/asciidoc/test.adoc
@@ -39,3 +39,13 @@ include::{snippets}/review-controller-test/update-review/http-request.adoc[]
 ==== 응답
 
 include::{snippets}/review-controller-test/update-review/http-response.adoc[]
+
+=== 리뷰 삭제 (DELETE /api/v1/reviews/\{reviewId\})
+
+==== 요청
+
+include::{snippets}/review-controller-test/delete-review/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/review-controller-test/delete-review/http-response.adoc[]

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/auth/domain/response/AccessTokenResponse.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/auth/domain/response/AccessTokenResponse.java
@@ -2,9 +2,11 @@ package edu.skku.grabtable.auth.domain.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class AccessTokenResponse {
     private String accessToken;
 }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/domain/Store.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/domain/Store.java
@@ -1,5 +1,6 @@
 package edu.skku.grabtable.domain;
 
+import edu.skku.grabtable.review.domain.Review;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/domain/User.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/domain/User.java
@@ -1,5 +1,6 @@
 package edu.skku.grabtable.domain;
 
+import edu.skku.grabtable.review.domain.Review;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -54,5 +55,11 @@ public class User extends BaseTimeEntity {
         this.socialLoginId = socialLoginId;
         this.username = nickname;
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public User(Long id, String username, List<Review> reviews) {
+        this.id = id;
+        this.username = username;
+        this.reviews = reviews;
     }
 }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/repository/StoreRepository.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/repository/StoreRepository.java
@@ -1,7 +1,10 @@
 package edu.skku.grabtable.repository;
 
 import edu.skku.grabtable.domain.Store;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
+
+    Optional<Store> findByStoreName(String storeName);
 }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/repository/UserRepository.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/repository/UserRepository.java
@@ -4,6 +4,7 @@ import edu.skku.grabtable.domain.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+
 public interface UserRepository extends JpaRepository<User, Long> {
     public Optional<User> findBySocialLoginId(String socialLoginId);
 }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/controller/ReviewController.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/controller/ReviewController.java
@@ -1,10 +1,10 @@
-package edu.skku.grabtable.controller;
+package edu.skku.grabtable.review.controller;
 
-import edu.skku.grabtable.domain.request.ReviewRequest;
-import edu.skku.grabtable.domain.request.ReviewUpdateRequest;
-import edu.skku.grabtable.domain.response.ReviewResponse;
-import edu.skku.grabtable.domain.response.ReviewSummaryResponse;
-import edu.skku.grabtable.service.ReviewService;
+import edu.skku.grabtable.review.domain.request.ReviewRequest;
+import edu.skku.grabtable.review.domain.request.ReviewUpdateRequest;
+import edu.skku.grabtable.review.domain.response.ReviewResponse;
+import edu.skku.grabtable.review.domain.response.ReviewSummaryResponse;
+import edu.skku.grabtable.review.service.ReviewService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/controller/ReviewController.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/controller/ReviewController.java
@@ -1,5 +1,7 @@
 package edu.skku.grabtable.review.controller;
 
+import edu.skku.grabtable.auth.annotation.AuthUser;
+import edu.skku.grabtable.domain.User;
 import edu.skku.grabtable.review.domain.request.ReviewRequest;
 import edu.skku.grabtable.review.domain.request.ReviewUpdateRequest;
 import edu.skku.grabtable.review.domain.response.ReviewResponse;
@@ -39,20 +41,28 @@ public class ReviewController {
         return reviewService.getReviewSummaryByStore(storeId);
     }
 
-    //밑의 모든 엔드포인트는 AUTH 모듈과 통합 필요
     @PostMapping
-    public void upload(@RequestBody @Valid ReviewRequest request) {
-        reviewService.upload(request);
+    public void upload(
+            @AuthUser User user,
+            @RequestBody @Valid ReviewRequest request
+    ) {
+        reviewService.upload(user.getId(), request);
     }
 
     @PatchMapping("/{reviewId}")
-    public void update(@RequestBody @Valid ReviewUpdateRequest request,
-                       @PathVariable Long reviewId) {
-        reviewService.update(reviewId, request.getMessage(), request.getRating());
+    public void update(
+            @AuthUser User user,
+            @RequestBody @Valid ReviewUpdateRequest request,
+            @PathVariable Long reviewId
+    ) {
+        reviewService.update(user.getId(), reviewId, request.getMessage(), request.getRating());
     }
 
     @DeleteMapping("/{reviewId}")
-    public void delete(@PathVariable Long reviewId) {
-        reviewService.delete(reviewId);
+    public void delete(
+            @AuthUser User user,
+            @PathVariable Long reviewId
+    ) {
+        reviewService.delete(user.getId(), reviewId);
     }
 }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/Review.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/Review.java
@@ -1,5 +1,8 @@
-package edu.skku.grabtable.domain;
+package edu.skku.grabtable.review.domain;
 
+import edu.skku.grabtable.domain.BaseTimeEntity;
+import edu.skku.grabtable.domain.Store;
+import edu.skku.grabtable.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/ReviewPlatform.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/ReviewPlatform.java
@@ -1,4 +1,4 @@
-package edu.skku.grabtable.domain;
+package edu.skku.grabtable.review.domain;
 
 public enum ReviewPlatform {
     NAVER, KAKAO, GRABTABLE

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/ReviewStatus.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/ReviewStatus.java
@@ -1,4 +1,4 @@
-package edu.skku.grabtable.domain;
+package edu.skku.grabtable.review.domain;
 
 public enum ReviewStatus {
     VALID, INVALID

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/request/ReviewRequest.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/request/ReviewRequest.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class ReviewRequest {
-
-    private Long userId;
     private Long storeId;
     private String message;
     private Double rating;

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/request/ReviewRequest.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/request/ReviewRequest.java
@@ -1,4 +1,4 @@
-package edu.skku.grabtable.domain.request;
+package edu.skku.grabtable.review.domain.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/request/ReviewUpdateRequest.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/request/ReviewUpdateRequest.java
@@ -1,4 +1,4 @@
-package edu.skku.grabtable.domain.request;
+package edu.skku.grabtable.review.domain.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/response/ReviewResponse.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/response/ReviewResponse.java
@@ -1,7 +1,7 @@
-package edu.skku.grabtable.domain.response;
+package edu.skku.grabtable.review.domain.response;
 
-import edu.skku.grabtable.domain.Review;
-import edu.skku.grabtable.domain.ReviewPlatform;
+import edu.skku.grabtable.review.domain.Review;
+import edu.skku.grabtable.review.domain.ReviewPlatform;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/response/ReviewSummaryResponse.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/domain/response/ReviewSummaryResponse.java
@@ -1,4 +1,4 @@
-package edu.skku.grabtable.domain.response;
+package edu.skku.grabtable.review.domain.response;
 
 import java.util.List;
 import java.util.Map;

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/repository/ReviewRepository.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/repository/ReviewRepository.java
@@ -1,6 +1,6 @@
-package edu.skku.grabtable.repository;
+package edu.skku.grabtable.review.repository;
 
-import edu.skku.grabtable.domain.Review;
+import edu.skku.grabtable.review.domain.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/repository/ReviewRepository.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/repository/ReviewRepository.java
@@ -1,7 +1,9 @@
 package edu.skku.grabtable.review.repository;
 
 import edu.skku.grabtable.review.domain.Review;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    List<Review> findByUserId(Long userId);
 }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/service/ReviewService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/service/ReviewService.java
@@ -50,7 +50,8 @@ public class ReviewService {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_REVIEW_ID));
 
-        if (!Objects.equals(review.getUser().getId(), userId)) {
+        User user = review.getUser();
+        if (user == null || !Objects.equals(user.getId(), userId)) {
             throw new BadRequestException(ExceptionCode.INVALID_REQUEST);
         }
 
@@ -60,7 +61,8 @@ public class ReviewService {
     public void update(Long userId, Long reviewId, String message, Double rating) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_STORE_ID));
-        if (!Objects.equals(review.getUser().getId(), userId)) {
+        User user = review.getUser();
+        if (user == null || !Objects.equals(user.getId(), userId)) {
             throw new BadRequestException(ExceptionCode.INVALID_REQUEST);
         }
         review.update(message, rating);

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/service/ReviewService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/service/ReviewService.java
@@ -14,6 +14,7 @@ import edu.skku.grabtable.review.repository.ReviewRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -45,22 +46,30 @@ public class ReviewService {
         return store.getReviews().stream().map(ReviewResponse::of).toList();
     }
 
-    public void delete(Long reviewId) {
+    public void delete(Long userId, Long reviewId) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_REVIEW_ID));
+
+        if (!Objects.equals(review.getUser().getId(), userId)) {
+            throw new BadRequestException(ExceptionCode.INVALID_REQUEST);
+        }
+
         reviewRepository.delete(review);
     }
 
-    public void update(Long reviewId, String message, Double rating) {
+    public void update(Long userId, Long reviewId, String message, Double rating) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_STORE_ID));
+        if (!Objects.equals(review.getUser().getId(), userId)) {
+            throw new BadRequestException(ExceptionCode.INVALID_REQUEST);
+        }
         review.update(message, rating);
     }
 
-    public void upload(ReviewRequest request) {
+    public void upload(Long userId, ReviewRequest request) {
         Store store = storeRepository.findById(request.getStoreId())
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_STORE_ID));
-        User user = userRepository.findById(request.getUserId())
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_USER_ID));
 
         Review review = Review.of(store, user, request.getMessage(), request.getRating());

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/service/ReviewService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/service/ReviewService.java
@@ -32,10 +32,12 @@ public class ReviewService {
 
     @Transactional(readOnly = true)
     public List<ReviewResponse> getAllReviewsByUser(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_USER_ID));
+//        User user = userRepository.findById(userId)
+//                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_USER_ID));
 
-        return user.getReviews().stream().map(ReviewResponse::of).toList();
+        List<Review> reviews = reviewRepository.findByUserId(userId);
+
+        return reviews.stream().map(ReviewResponse::of).toList();
     }
 
     @Transactional(readOnly = true)

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/service/ReviewService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/service/ReviewService.java
@@ -1,16 +1,16 @@
-package edu.skku.grabtable.service;
+package edu.skku.grabtable.review.service;
 
 import edu.skku.grabtable.common.exception.BadRequestException;
 import edu.skku.grabtable.common.exception.ExceptionCode;
-import edu.skku.grabtable.domain.Review;
 import edu.skku.grabtable.domain.Store;
 import edu.skku.grabtable.domain.User;
-import edu.skku.grabtable.domain.request.ReviewRequest;
-import edu.skku.grabtable.domain.response.ReviewResponse;
-import edu.skku.grabtable.domain.response.ReviewSummaryResponse;
-import edu.skku.grabtable.repository.ReviewRepository;
 import edu.skku.grabtable.repository.StoreRepository;
 import edu.skku.grabtable.repository.UserRepository;
+import edu.skku.grabtable.review.domain.Review;
+import edu.skku.grabtable.review.domain.request.ReviewRequest;
+import edu.skku.grabtable.review.domain.response.ReviewResponse;
+import edu.skku.grabtable.review.domain.response.ReviewSummaryResponse;
+import edu.skku.grabtable.review.repository.ReviewRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/auth/controller/LoginControllerTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/auth/controller/LoginControllerTest.java
@@ -1,0 +1,112 @@
+package edu.skku.grabtable.auth.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.skku.grabtable.auth.JwtUtil;
+import edu.skku.grabtable.auth.domain.UserTokens;
+import edu.skku.grabtable.auth.domain.request.LoginRequest;
+import edu.skku.grabtable.auth.domain.response.AccessTokenResponse;
+import edu.skku.grabtable.auth.repository.RefreshTokenRepository;
+import edu.skku.grabtable.auth.service.LoginService;
+import edu.skku.grabtable.common.ControllerTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(LoginController.class)
+@AutoConfigureRestDocs
+class LoginControllerTest extends ControllerTest {
+
+    private static final String ACCESS_TOKEN = "access_token";
+    private static final String REISSUED_ACCESS_TOKEN = "reissued_access_token";
+    private static final String REFRESH_TOKEN = "refresh_token";
+    private static final String CODE = "code";
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    LoginService loginService;
+
+    @MockBean
+    RefreshTokenRepository refreshTokenRepository;
+
+    @MockBean
+    JwtUtil jwtUtil;
+
+    @Test
+    @DisplayName("카카오 소셜 로그인을 할 수 있다.")
+    void kakaoSocialLogin() throws Exception {
+        //given
+        LoginRequest loginRequest = new LoginRequest(CODE);
+
+        Mockito.when(loginService.login(ArgumentMatchers.any()))
+                .thenReturn(new UserTokens(REFRESH_TOKEN, ACCESS_TOKEN));
+        //when
+        MvcResult mvcResult = mockMvc.perform(post("/v1/auth/login/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+        //then
+        AccessTokenResponse accessTokenResponse = objectMapper.readValue(
+                mvcResult.getResponse().getContentAsString(),
+                AccessTokenResponse.class
+        );
+
+        assertThat(accessTokenResponse.getAccessToken()).isEqualTo(ACCESS_TOKEN);
+    }
+
+    @Test
+    @DisplayName("Access Token을 재발급받을 수 있다.")
+    void reissueToken() throws Exception {
+        //given
+        Mockito.when(loginService.reissueAccessToken(REFRESH_TOKEN, ACCESS_TOKEN))
+                .thenReturn(REISSUED_ACCESS_TOKEN);
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(post("/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .cookie(new Cookie("refresh-token", REFRESH_TOKEN)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        AccessTokenResponse accessTokenResponse = objectMapper.readValue(
+                mvcResult.getResponse().getContentAsString(),
+                AccessTokenResponse.class
+        );
+
+        assertThat(accessTokenResponse.getAccessToken()).isEqualTo(REISSUED_ACCESS_TOKEN);
+
+    }
+
+    @Test
+    @DisplayName("로그아웃할 수 있다.")
+    void logout() throws Exception {
+        //given
+        Mockito.doNothing().when(loginService).logout(ArgumentMatchers.any());
+
+        //when
+        mockMvc.perform(post("/v1/auth/logout")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .cookie(new Cookie("refresh-token", REFRESH_TOKEN)))
+                .andExpect(status().isNoContent());
+
+        //then
+        Mockito.verify(loginService).logout(ArgumentMatchers.any());
+    }
+
+
+}

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/common/ControllerTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/common/ControllerTest.java
@@ -1,0 +1,43 @@
+package edu.skku.grabtable.common;
+
+import edu.skku.grabtable.auth.AuthUserArgumentResolver;
+import edu.skku.grabtable.common.config.RestDocsConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith(RestDocumentationExtension.class)
+@Import(RestDocsConfiguration.class)
+public abstract class ControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @MockBean
+    protected AuthUserArgumentResolver authUserArgumentResolver;
+
+    @Autowired
+    protected RestDocumentationResultHandler restDocs;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context, RestDocumentationContextProvider restDoc) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(restDoc))
+                .alwaysDo(MockMvcResultHandlers.print())
+                .alwaysDo(restDocs)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+
+}

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/common/config/RestDocsConfiguration.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/common/config/RestDocsConfiguration.java
@@ -1,0 +1,20 @@
+package edu.skku.grabtable.common.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+@TestConfiguration
+public class RestDocsConfiguration {
+
+    @Bean
+    public RestDocumentationResultHandler write() {
+        return MockMvcRestDocumentation.document(
+                "{class-name}/{method-name}",
+                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+        );
+    }
+}

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/integration/ReviewIntegrationTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/integration/ReviewIntegrationTest.java
@@ -21,11 +21,11 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@Transactional
 @Sql(value = {
         "classpath:data/stores.sql",
         "classpath:data/reviews.sql"
 })
-@Transactional
 public class ReviewIntegrationTest {
 
     @Autowired
@@ -58,13 +58,14 @@ public class ReviewIntegrationTest {
         User findUser = userRepository.findById(savedUser.getId()).get();
         Store store = storeRepository.findByStoreName("봉수육").get();
         reviewService.upload(findUser.getId(), new ReviewRequest(store.getId(), "맛있어요", 4.0));
-        ReviewResponse reviewResponse = reviewService.getAllReviewsByUser(findUser.getId()).get(0);
 
         //when
+        ReviewResponse reviewResponse = reviewService.getAllReviewsByUser(findUser.getId()).get(0);
+        System.out.println("findUser = " + findUser.getId());
+        System.out.println("reviewResponse = " + reviewResponse);
         reviewService.delete(findUser.getId(), reviewResponse.getId());
 
         //then
-
         //NativeQuery를 통해 JPA 설정을 우회할 수 있다.
         Review deletedReview = (Review) em.createNativeQuery("select * from review where status = 'INVALID'",
                         Review.class)

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/integration/ReviewIntegrationTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/integration/ReviewIntegrationTest.java
@@ -54,11 +54,11 @@ public class ReviewIntegrationTest {
         User savedUser = userRepository.save(user);
         User findUser = userRepository.findById(savedUser.getId()).get();
         Store store = storeRepository.findByStoreName("봉수육").get();
-        reviewService.upload(new ReviewRequest(findUser.getId(), store.getId(), "맛있어요", 4.0));
+        reviewService.upload(findUser.getId(), new ReviewRequest(store.getId(), "맛있어요", 4.0));
         ReviewResponse reviewResponse = reviewService.getAllReviewsByUser(findUser.getId()).get(0);
 
         //when
-        reviewService.delete(reviewResponse.getId());
+        reviewService.delete(findUser.getId(), reviewResponse.getId());
 
         //then
 

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/integration/ReviewIntegrationTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/integration/ReviewIntegrationTest.java
@@ -1,15 +1,15 @@
 package edu.skku.grabtable.integration;
 
-import edu.skku.grabtable.domain.Review;
-import edu.skku.grabtable.domain.ReviewStatus;
 import edu.skku.grabtable.domain.Store;
 import edu.skku.grabtable.domain.User;
-import edu.skku.grabtable.domain.request.ReviewRequest;
-import edu.skku.grabtable.domain.response.ReviewResponse;
-import edu.skku.grabtable.repository.ReviewRepository;
 import edu.skku.grabtable.repository.StoreRepository;
 import edu.skku.grabtable.repository.UserRepository;
-import edu.skku.grabtable.service.ReviewService;
+import edu.skku.grabtable.review.domain.Review;
+import edu.skku.grabtable.review.domain.ReviewStatus;
+import edu.skku.grabtable.review.domain.request.ReviewRequest;
+import edu.skku.grabtable.review.domain.response.ReviewResponse;
+import edu.skku.grabtable.review.repository.ReviewRepository;
+import edu.skku.grabtable.review.service.ReviewService;
 import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/review/controller/ReviewControllerTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/review/controller/ReviewControllerTest.java
@@ -5,67 +5,34 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.skku.grabtable.auth.AuthUserArgumentResolver;
-import edu.skku.grabtable.common.config.RestDocsConfiguration;
+import edu.skku.grabtable.common.ControllerTest;
 import edu.skku.grabtable.review.domain.ReviewPlatform;
 import edu.skku.grabtable.review.domain.request.ReviewRequest;
 import edu.skku.grabtable.review.domain.request.ReviewUpdateRequest;
 import edu.skku.grabtable.review.domain.response.ReviewResponse;
 import edu.skku.grabtable.review.service.ReviewService;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 @WebMvcTest(ReviewController.class)
-@ExtendWith(RestDocumentationExtension.class)
-@Import(RestDocsConfiguration.class)
 @AutoConfigureRestDocs
-class ReviewControllerTest {
+class ReviewControllerTest extends ControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
 
     @MockBean
     private ReviewService reviewService;
 
-    @MockBean
-    private AuthUserArgumentResolver authUserArgumentResolver;
-
     @Autowired
     private ObjectMapper objectMapper;
-
-    @Autowired
-    RestDocumentationResultHandler restDocs;
-
-    @BeforeEach
-    void setUp(WebApplicationContext context, RestDocumentationContextProvider restDoc) {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-                .apply(MockMvcRestDocumentation.documentationConfiguration(restDoc))
-                .alwaysDo(MockMvcResultHandlers.print())
-                .alwaysDo(restDocs)
-                .addFilter(new CharacterEncodingFilter("UTF-8", true))
-                .build();
-    }
 
     @Test
     @DisplayName("유저가 작성한 리뷰를 조회할 수 있다.")

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/review/controller/ReviewControllerTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/review/controller/ReviewControllerTest.java
@@ -6,11 +6,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.skku.grabtable.common.ControllerTest;
+import edu.skku.grabtable.domain.User;
 import edu.skku.grabtable.review.domain.ReviewPlatform;
 import edu.skku.grabtable.review.domain.request.ReviewRequest;
 import edu.skku.grabtable.review.domain.request.ReviewUpdateRequest;
 import edu.skku.grabtable.review.domain.response.ReviewResponse;
 import edu.skku.grabtable.review.service.ReviewService;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -89,11 +91,12 @@ class ReviewControllerTest extends ControllerTest {
 
     @Test
     @DisplayName("유저는 리뷰를 등록할 수 있다.")
-    void UploadReview() throws Exception {
+    void uploadReview() throws Exception {
 
         //given
-        ReviewRequest request = new ReviewRequest(1L, 1L, "good", 3.5);
-        Mockito.doNothing().when(reviewService).upload(ArgumentMatchers.any());
+        User user = new User(1L, "userA", new ArrayList<>());
+        ReviewRequest request = new ReviewRequest(1L, "good", 3.5);
+        Mockito.doNothing().when(reviewService).upload(ArgumentMatchers.any(), ArgumentMatchers.any());
 
         //when
         mockMvc.perform(MockMvcRequestBuilders.post("/v1/reviews")
@@ -103,16 +106,17 @@ class ReviewControllerTest extends ControllerTest {
                 .andExpect(status().isOk());
 
         //then
-        Mockito.verify(reviewService).upload(ArgumentMatchers.any());
+        Mockito.verify(reviewService).upload(ArgumentMatchers.any(), ArgumentMatchers.any());
     }
 
     @Test
     @DisplayName("유저는 리뷰를 수정할 수 있다.")
-    void UpdateReview() throws Exception {
+    void updateReview() throws Exception {
 
         //given
         ReviewUpdateRequest request = new ReviewUpdateRequest("good", 3.5);
         Mockito.doNothing().when(reviewService).update(
+                ArgumentMatchers.anyLong(),
                 ArgumentMatchers.anyLong(),
                 ArgumentMatchers.any(),
                 ArgumentMatchers.anyDouble());
@@ -126,8 +130,29 @@ class ReviewControllerTest extends ControllerTest {
 
         //then
         Mockito.verify(reviewService).update(
+                ArgumentMatchers.any(),
                 ArgumentMatchers.anyLong(),
                 ArgumentMatchers.any(),
                 ArgumentMatchers.anyDouble());
+    }
+
+    @Test
+    @DisplayName("유저는 리뷰를 삭제할 수 있다.")
+    void deleteReview() throws Exception {
+        //given
+        Mockito.doNothing().when(reviewService).delete(
+                ArgumentMatchers.anyLong(),
+                ArgumentMatchers.anyLong());
+
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.delete("/v1/reviews/{reviewId}", "1"))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        //then
+        Mockito.verify(reviewService).delete(
+                ArgumentMatchers.any(),
+                ArgumentMatchers.anyLong()
+        );
     }
 }

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/review/service/ReviewServiceTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/review/service/ReviewServiceTest.java
@@ -50,7 +50,8 @@ class ReviewServiceTest {
         user.getReviews().add(review);
         user.getReviews().add(review2);
 
-        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(user));
+        when(reviewRepository.findByUserId(any(Long.class)))
+                .thenReturn(List.of(review, review2));
 
         //when
         List<ReviewResponse> result = reviewService.getAllReviewsByUser(user.getId());

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/review/service/ReviewServiceTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/review/service/ReviewServiceTest.java
@@ -1,19 +1,19 @@
-package edu.skku.grabtable.service;
+package edu.skku.grabtable.review.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import edu.skku.grabtable.domain.Review;
 import edu.skku.grabtable.domain.Store;
 import edu.skku.grabtable.domain.StoreCategory;
 import edu.skku.grabtable.domain.StoreStatus;
 import edu.skku.grabtable.domain.User;
-import edu.skku.grabtable.domain.response.ReviewResponse;
-import edu.skku.grabtable.domain.response.ReviewSummaryResponse;
-import edu.skku.grabtable.repository.ReviewRepository;
 import edu.skku.grabtable.repository.StoreRepository;
 import edu.skku.grabtable.repository.UserRepository;
+import edu.skku.grabtable.review.domain.Review;
+import edu.skku.grabtable.review.domain.response.ReviewResponse;
+import edu.skku.grabtable.review.domain.response.ReviewSummaryResponse;
+import edu.skku.grabtable.review.repository.ReviewRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -43,7 +43,7 @@ class ReviewServiceTest {
     @DisplayName("User ID로 유저가 작성한 모든 리뷰를 조회할 수 있다")
     void findReviewsByUserId() {
         //given
-        User user = new User(1L, "a", "b", "c", "d", new ArrayList<>());
+        User user = new User(1L, "userA", new ArrayList<>());
         Store store = new Store("Ramen", "Seoul");
         Review review = Review.of(store, user, "a", 3.0);
         Review review2 = Review.of(store, user, "b", 4.0);
@@ -63,7 +63,7 @@ class ReviewServiceTest {
     @DisplayName("Store ID로 가게의 모든 리뷰를 조회할 수 있다")
     void findReviewsByStoreId() {
         //given
-        User user = new User(1L, "a", "b", "c", "d", new ArrayList<>());
+        User user = new User(1L, "userA", new ArrayList<>());
         Store store = new Store(1L, "Ramen", "Seoul", null, null, null,
                 StoreStatus.VALID, StoreCategory.JAPANESE, new ArrayList<>());
         Review review = Review.of(store, user, "a", 3.0);
@@ -84,7 +84,7 @@ class ReviewServiceTest {
     @DisplayName("가게 리뷰 요약을 조회할 수 있다.")
     void getReviewSummary() {
         //given
-        User user = new User(1L, "a", "b", "c", "d", new ArrayList<>());
+        User user = new User(1L, "userA", new ArrayList<>());
         Store store = new Store(1L, "Ramen", "Seoul", null, null, null,
                 StoreStatus.VALID, StoreCategory.JAPANESE, new ArrayList<>());
         Review review = Review.of(store, user, "a", 3.0);


### PR DESCRIPTION
### Type of Issue

resolve #22 

### Key Change

<!-- 핵심 변화를 나열해주세요. -->
- .adoc 파일 작성
- Review 모듈 테스트 코드 수정
- LoginController 테스트 코드 작성

### docs 작성법

- 모듈의 ControllerTest를 작성할 때 ControllerTest를 상속받는다.
    + e.g. `class LoginControllerTest extends ControllerTest`
- `@WebMvcTest({controller-name}.class)`, `@AutoConfigureRestdocs` 어노테이션을 적용한다.
- `src/docs/asciidoc`에 작성한 테스트의 adoc 파일 역시 작성해주고, `index.adoc`에 통합시킨다.
- `gradle build` 커맨드로 `resources/static/docs`에서 빌드된 문서를 확인할 수 있다.

### 결과 화면
![image](https://github.com/GrabTable/GrabTable/assets/85350805/7df71fd5-8964-4ea7-9611-fe7a6f259cac)
