### PR TITLE
[Feature] 세션 스토리지 Redis 도입

### DIFF
--- a/backend/grabtable/build.gradle
+++ b/backend/grabtable/build.gradle
@@ -35,19 +35,22 @@ dependencies {
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-    // auth
+    //auth
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    //payment
+    //iamport payment
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.21'
     //spring rest docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.register('copyYml', Copy) {

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/auth/domain/RefreshToken.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/auth/domain/RefreshToken.java
@@ -1,16 +1,16 @@
 package edu.skku.grabtable.auth.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
 
-@Entity
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "jwt", timeToLive = 60 * 60 * 24 * 7)
 public class RefreshToken {
     @Id
     private Long userId;

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/auth/repository/RefreshTokenRepository.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/auth/repository/RefreshTokenRepository.java
@@ -2,11 +2,8 @@ package edu.skku.grabtable.auth.repository;
 
 import edu.skku.grabtable.auth.domain.RefreshToken;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.repository.CrudRepository;
 
-@Repository
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByValue(String value);
 }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/common/config/RedisConfig.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/common/config/RedisConfig.java
@@ -1,0 +1,39 @@
+package edu.skku.grabtable.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        return redisTemplate;
+    }
+
+
+}


### PR DESCRIPTION
### Type of Issue

<!-- 
이슈 번호와 간단한 설명을 적어주세요. 
resolve #<이슈번호> 넣으면 PR close시 자동으로 이슈도 close 됩니다.
ex. resolve #1
-->

resolve #72 

### Key Change

<!-- 핵심 변화를 나열해주세요. -->
- 이제 RefreshToken이 기존 Mysql 대신 Redis에 저장됩니다.
- Redis를 로컬 환경에 설치해야 정상 작동합니다.
- 설치 및 컨테이너 접속 방법
```
$ docker pull redis
$ docker run -p 6379:6379 redis
$ docker exec -it redis /bin/bash
```
- 실행 방법
```
# redis-cli
```
- 키 및 값 확인 방법
```
127.0.0.1:6379> keys *
127.0.0.1:6379> hgetall <key-name>
```