### PR TITLE
Feat(be): 지도뷰 위한 가게 데이터에 위도, 경도 추가

### DIFF
--- a/backend/grabtable/src/main/java/edu/skku/grabtable/store/domain/Store.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/store/domain/Store.java
@@ -2,6 +2,7 @@ package edu.skku.grabtable.store.domain;
 
 import edu.skku.grabtable.common.domain.BaseTimeEntity;
 import edu.skku.grabtable.review.domain.Review;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -29,6 +30,9 @@ public class Store extends BaseTimeEntity {
     private String storeName;
 
     private String address;
+
+    @Embedded
+    private StorePosition position;
 
     private String storePictureUrl;
 

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/store/domain/StorePosition.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/store/domain/StorePosition.java
@@ -1,0 +1,15 @@
+package edu.skku.grabtable.store.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class StorePosition {
+    
+    private Double latitude;
+    private Double longitude;
+}

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/store/domain/response/StoreInfoResponse.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/store/domain/response/StoreInfoResponse.java
@@ -13,6 +13,8 @@ import lombok.ToString;
 public class StoreInfoResponse {
     private Long id;
     private String storeName;
+    private Double latitude;
+    private Double longitude;
     private String address;
     private String storePictureUrl;
     private String category;
@@ -22,6 +24,8 @@ public class StoreInfoResponse {
         return new StoreInfoResponse(
                 store.getId(),
                 store.getStoreName(),
+                store.getPosition().getLatitude(),
+                store.getPosition().getLongitude(),
                 store.getAddress(),
                 store.getStorePictureUrl(),
                 store.getCategory().toString(),

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/order/service/SharedOrderServiceTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/order/service/SharedOrderServiceTest.java
@@ -57,7 +57,7 @@ class SharedOrderServiceTest {
         //given
         User user = new User(1L, "kakaoUser", "url", "userA", "1234", "email", "phone", null, new ArrayList<>(),
                 new ArrayList<>());
-        Store store = new Store(1L, "Ramen", "Seoul", null, null, null,
+        Store store = new Store(1L, "Ramen", "Seoul", null, null, null, null,
                 StoreStatus.VALID, StoreCategory.JAPANESE, new ArrayList<>(), new ArrayList<>());
         Reservation reservation = new Reservation(user, store);
         SharedOrder sharedOrder = reservation.getSharedOrder();
@@ -103,7 +103,7 @@ class SharedOrderServiceTest {
         //given
         User user = new User(1L, "kakaoUser", "url", "userA", "1234", "email", "phone", null, new ArrayList<>(),
                 new ArrayList<>());
-        Store store = new Store(1L, "Ramen", "Seoul", null, null, null,
+        Store store = new Store(1L, "Ramen", "Seoul", null, null, null, null,
                 StoreStatus.VALID, StoreCategory.JAPANESE, new ArrayList<>(), new ArrayList<>());
         Reservation reservation = new Reservation(user, store);
         SharedOrder sharedOrder = reservation.getSharedOrder();

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/reservation/service/ReservationServiceTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/reservation/service/ReservationServiceTest.java
@@ -45,7 +45,7 @@ class ReservationServiceTest {
     void host_create_fail() {
         User user = new User(1L, "kakaoUser", "url", "userA", "1234", "email", "phone", null, new ArrayList<>(),
                 new ArrayList<>());
-        Store store = new Store(1L, "storeA", "Seoul", "url", "phone", "desc", StoreStatus.VALID,
+        Store store = new Store(1L, "storeA", "Seoul", null, "url", "phone", "desc", StoreStatus.VALID,
                 StoreCategory.JAPANESE,
                 new ArrayList<>(), new ArrayList<>());
 
@@ -67,7 +67,7 @@ class ReservationServiceTest {
     void host_participate_fail() {
         User user = new User(1L, "kakaoUser", "url", "userA", "1234", "email", "phone", null, new ArrayList<>(),
                 new ArrayList<>());
-        Store store = new Store(1L, "storeA", "Seoul", "url", "phone", "desc", StoreStatus.VALID,
+        Store store = new Store(1L, "storeA", "Seoul", null, "url", "phone", "desc", StoreStatus.VALID,
                 StoreCategory.JAPANESE,
                 new ArrayList<>(), new ArrayList<>());
         Reservation reservation = new Reservation(user, store);
@@ -89,7 +89,7 @@ class ReservationServiceTest {
         Reservation reservation = new Reservation(1L, null, null, null, null, null, ReservationStatus.ONGOING);
         User user = new User(1L, "kakaoUser", "url", "userA", "1234", "email", "phone", reservation, new ArrayList<>(),
                 new ArrayList<>());
-        Store store = new Store(1L, "storeA", "Seoul", "url", "phone", "desc", StoreStatus.VALID,
+        Store store = new Store(1L, "storeA", "Seoul", null, "url", "phone", "desc", StoreStatus.VALID,
                 StoreCategory.JAPANESE,
                 new ArrayList<>(), new ArrayList<>());
 
@@ -111,7 +111,7 @@ class ReservationServiceTest {
         Reservation reservation2 = new Reservation(2L, null, null, null, null, null, ReservationStatus.ONGOING);
         User user = new User(1L, "kakaoUser", "url", "userA", "1234", "email", "phone", reservation, new ArrayList<>(),
                 new ArrayList<>());
-        Store store = new Store(1L, "storeA", "Seoul", "url", "phone", "desc", StoreStatus.VALID,
+        Store store = new Store(1L, "storeA", "Seoul", null, "url", "phone", "desc", StoreStatus.VALID,
                 StoreCategory.JAPANESE,
                 new ArrayList<>(), new ArrayList<>());
 

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/review/service/ReviewServiceTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/review/service/ReviewServiceTest.java
@@ -65,7 +65,7 @@ class ReviewServiceTest {
     void findReviewsByStoreId() {
         //given
         User user = new User(1L, "userA", new ArrayList<>());
-        Store store = new Store(1L, "Ramen", "Seoul", null, null, null,
+        Store store = new Store(1L, "Ramen", "Seoul", null, null, null, null,
                 StoreStatus.VALID, StoreCategory.JAPANESE, new ArrayList<>(), new ArrayList<>());
         Review review = Review.of(store, user, "a", 3.0);
         Review review2 = Review.of(store, user, "b", 4.0);
@@ -86,7 +86,7 @@ class ReviewServiceTest {
     void getReviewSummary() {
         //given
         User user = new User(1L, "userA", new ArrayList<>());
-        Store store = new Store(1L, "Ramen", "Seoul", null, null, null,
+        Store store = new Store(1L, "Ramen", "Seoul", null, null, null, null,
                 StoreStatus.VALID, StoreCategory.JAPANESE, new ArrayList<>(), new ArrayList<>());
         Review review = Review.of(store, user, "a", 3.0);
         Review review2 = Review.of(store, user, "b", 4.0);

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/store/controller/StoreControllerTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/store/controller/StoreControllerTest.java
@@ -34,9 +34,9 @@ class StoreControllerTest extends ControllerTest {
     @Test
     @DisplayName("가게 목록을 조회할 수 있다.")
     void findStores() throws Exception {
-        StoreInfoResponse store1 = new StoreInfoResponse(1L, "봉수육", "경기 수원시 장안구 화산로", "",
+        StoreInfoResponse store1 = new StoreInfoResponse(1L, "봉수육", 1.0, 2.0, "경기 수원시 장안구 화산로", "",
                 "KOREAN", 4.5);
-        StoreInfoResponse store2 = new StoreInfoResponse(1L, "미가라멘", "경기 수원시 장안구 화산로", "",
+        StoreInfoResponse store2 = new StoreInfoResponse(1L, "미가라멘", 2.0, 4.0, "경기 수원시 장안구 화산로", "",
                 "JAPANESE", 4.23);
         List<StoreInfoResponse> storesResponse = List.of(store1, store2);
 

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/store/service/StoreServiceTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/store/service/StoreServiceTest.java
@@ -36,7 +36,7 @@ class StoreServiceTest {
     @DisplayName("가게 ID로 가게 메뉴를 조회할 수 있다.")
     void findMenusByStoreId() {
         //given
-        Store store = new Store(1L, "Ramen", "Seoul", null, null, null,
+        Store store = new Store(1L, "Ramen", "Seoul", null, null, null, null,
                 StoreStatus.VALID, StoreCategory.JAPANESE, new ArrayList<>(), new ArrayList<>());
         Menu menu1 = new Menu(1L, store, "돈코츠라멘", 10000, null, MenuStatus.VALID);
         Menu menu2 = new Menu(1L, store, "미소라멘", 8000, null, MenuStatus.VALID);


### PR DESCRIPTION
### Type of Issue

<!-- 
이슈 번호와 간단한 설명을 적어주세요. 
resolve #<이슈번호> 넣으면 PR close시 자동으로 이슈도 close 됩니다.
ex. resolve #1
-->

resolve #93 

### Key Change

- `/v1/stores` API 호출 시 위도, 경도가 포함됩니다.

- 예시 response body

```
{
"id": 1,
"storeName": "먹깨비김밥",
"latitude": 37.2987099,
"longitude": 126.9713822,
"address": null,
"storePictureUrl": null,
"category": "KOREAN",
"averageRating": 2.3846153846153846
},
{
"id": 2,
"storeName": "봉수육",
"latitude": 37.2989374,
"longitude": 126.9699545,
"address": null,
"storePictureUrl": null,
"category": "KOREAN",
"averageRating": 4.112903225806452
},
```


<!-- 핵심 변화를 나열해주세요. -->