### PR TITLE
Test(be): 예약-주문-카트 통합 테스트 작성

### DIFF
--- a/backend/grabtable/src/main/java/edu/skku/grabtable/cart/domain/Cart.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/cart/domain/Cart.java
@@ -29,7 +29,7 @@ public class Cart extends BaseTimeEntity {
 
     private String menuName;
 
-    private Integer price;
+    private Integer unitPrice;
 
     @ManyToOne
     private Order order;
@@ -42,14 +42,14 @@ public class Cart extends BaseTimeEntity {
     public Cart(User user, Menu menu, Integer quantity) {
         this.user = user;
         this.menuName = menu.getMenuName();
-        this.price = menu.getPrice();
+        this.unitPrice = menu.getPrice();
         this.quantity = quantity;
     }
 
     public Cart(SharedOrder sharedOrder, Menu menu, Integer quantity) {
         this.sharedOrder = sharedOrder;
         this.menuName = menu.getMenuName();
-        this.price = menu.getPrice();
+        this.unitPrice = menu.getPrice();
         this.quantity = quantity;
     }
 
@@ -58,7 +58,7 @@ public class Cart extends BaseTimeEntity {
     }
 
     public int calculateTotalPrice() {
-        return this.price * this.quantity;
+        return this.unitPrice * this.quantity;
     }
 
     public void disconnectUser() {

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/cart/domain/response/CartResponse.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/cart/domain/response/CartResponse.java
@@ -20,7 +20,7 @@ public class CartResponse {
                 cart.getId(),
                 cart.getMenuName(),
                 cart.getQuantity(),
-                cart.getPrice(),
+                cart.getUnitPrice(),
                 cart.calculateTotalPrice()
         );
     }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/cart/service/CartService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/cart/service/CartService.java
@@ -105,7 +105,7 @@ public class CartService {
     /* === 검증 메서드 ==== */
 
     private void validateUserHasPaidOrder(User user) {
-        Reservation reservation = reservationRepository.findByUser(user)
+        Reservation reservation = reservationRepository.findOngoingReservationByUser(user)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NO_RESERVATION_USER));
 
         if (orderRepository.findByReservationAndUser(reservation, user).isPresent()) {

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/cart/service/CartService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/cart/service/CartService.java
@@ -67,7 +67,7 @@ public class CartService {
 
     /* === 공유 주문 기능 === */
     public void createCartInSharedOrder(User user, Long menuId, Integer quantity) {
-        Reservation reservation = reservationRepository.findByUser(user)
+        Reservation reservation = reservationRepository.findOngoingReservationByUser(user)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NO_RESERVATION_USER));
         SharedOrder sharedOrder = reservation.getSharedOrder();
         Menu menu = menuRepository.findById(menuId)
@@ -114,7 +114,7 @@ public class CartService {
     }
 
     private void validateStoreContainsMenu(User user, Menu menu) {
-        Reservation reservation = reservationRepository.findByUser(user)
+        Reservation reservation = reservationRepository.findOngoingReservationByUser(user)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NO_RESERVATION_USER));
 
         if (!menu.getStore().equals(reservation.getStore())) {
@@ -123,7 +123,7 @@ public class CartService {
     }
 
     private void validateUserHasReservation(User user) {
-        if (reservationRepository.findByUser(user).isEmpty()) {
+        if (reservationRepository.findOngoingReservationByUser(user).isEmpty()) {
             throw new BadRequestException(ExceptionCode.NO_RESERVATION_USER);
         }
     }
@@ -147,7 +147,7 @@ public class CartService {
     }
 
     private void validateAuthInSharedOrder(User user, Cart cart) {
-        Reservation reservation = reservationRepository.findByUser(user)
+        Reservation reservation = reservationRepository.findOngoingReservationByUser(user)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NO_RESERVATION_USER));
         SharedOrder sharedOrder = reservation.getSharedOrder();
 
@@ -157,7 +157,7 @@ public class CartService {
     }
 
     private void validateNoPaidInSharedOrder(User user) {
-        Reservation reservation = reservationRepository.findByUser(user)
+        Reservation reservation = reservationRepository.findOngoingReservationByUser(user)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NO_RESERVATION_USER));
         SharedOrder sharedOrder = reservation.getSharedOrder();
 

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/common/exception/ExceptionCode.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/common/exception/ExceptionCode.java
@@ -33,7 +33,9 @@ public enum ExceptionCode {
     NOT_ENOUGH_ORDER(5003, "미결제 인원이 존재하여 예약을 확정할 수 없습니다."),
     TOO_MUCH_PAYING_AMOUNT(5004, "지불 요청 금액이 잔여 금액보다 많습니다."),
     ALREADY_PAID_USER(5005, "이미 개인 주문 결제를 완료한 사용자입니다."),
-    HAS_PAID_IN_SHARED_ORDER(5006, "결제를 완료한 사용자가 있어 장바구니를 변경할 수 없습니다.");
+    HAS_PAID_IN_SHARED_ORDER(5006, "결제를 완료한 사용자가 있어 장바구니를 변경할 수 없습니다."),
+    INVALID_PAY_AMOUNT(5007, "결제 요청 금액이 실제 결제해야 할 금액과 일치하지 않습니다."),
+    ;
 
     private final int code;
     private final String message;

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/common/exception/ExceptionCode.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/common/exception/ExceptionCode.java
@@ -30,12 +30,12 @@ public enum ExceptionCode {
 
     CURRENT_CARTS_EMPTY(5001, "사용자의 장바구니가 비어 있습니다."),
     FAILED_TO_VALIDATE_PAYMENT(5002, "결제 검증에 실패했습니다."),
-    NOT_ENOUGH_ORDER(5003, "미결제 인원이 존재하여 예약을 확정할 수 없습니다."),
+    NO_ORDER_FOUND_IN_RESERVATION(5003, "예약 내 결제된 주문이 존재하지 않습니다."),
     TOO_MUCH_PAYING_AMOUNT(5004, "지불 요청 금액이 잔여 금액보다 많습니다."),
     ALREADY_PAID_USER(5005, "이미 개인 주문 결제를 완료한 사용자입니다."),
     HAS_PAID_IN_SHARED_ORDER(5006, "결제를 완료한 사용자가 있어 장바구니를 변경할 수 없습니다."),
     INVALID_PAY_AMOUNT(5007, "결제 요청 금액이 실제 결제해야 할 금액과 일치하지 않습니다."),
-    ;
+    UNPAID_AMOUNT_EXIST(5008, "공유 장바구니의 전체 금액이 결제되어야 예약을 확정할 수 있습니다.");
 
     private final int code;
     private final String message;

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/order/domain/Order.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/order/domain/Order.java
@@ -68,7 +68,7 @@ public class Order extends BaseTimeEntity {
         this.status = OrderStatus.PAID;
     }
 
-    public Order(User user, SharedOrder sharedOrder, int amount) {
+    public Order(SharedOrder sharedOrder, User user, int amount) {
         this.sharedOrder = sharedOrder;
         this.user = user;
         changeCartsMapping(carts);

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/order/domain/SharedOrder.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/order/domain/SharedOrder.java
@@ -3,6 +3,7 @@ package edu.skku.grabtable.order.domain;
 import edu.skku.grabtable.cart.domain.Cart;
 import edu.skku.grabtable.common.domain.BaseTimeEntity;
 import edu.skku.grabtable.reservation.domain.Reservation;
+import edu.skku.grabtable.user.domain.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -17,11 +18,13 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE shared_order SET order_status = 'CANCELED' where id = ?")
 public class SharedOrder extends BaseTimeEntity {
 
     @Id
@@ -45,6 +48,12 @@ public class SharedOrder extends BaseTimeEntity {
         sharedOrder.reservation = reservation;
         sharedOrder.orderStatus = OrderStatus.PENDING;
         return sharedOrder;
+    }
+
+    public Order addOrder(User user, int amount) {
+        Order order = new Order(this, user, amount);
+        this.orders.add(order);
+        return order;
     }
 
     public int calculateTotalAmount() {

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/order/repository/SharedOrderRepository.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/order/repository/SharedOrderRepository.java
@@ -1,0 +1,11 @@
+package edu.skku.grabtable.order.repository;
+
+import edu.skku.grabtable.order.domain.SharedOrder;
+import edu.skku.grabtable.reservation.domain.Reservation;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SharedOrderRepository extends JpaRepository<SharedOrder, Long> {
+
+    Optional<SharedOrder> findByReservation(Reservation reservation);
+}

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/order/service/OrderService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/order/service/OrderService.java
@@ -28,7 +28,7 @@ public class OrderService {
     private final PaymentValidator validator;
 
     public OrderResponse processPayment(User user, PaymentRequest paymentRequest) {
-        Reservation reservation = reservationRepository.findByUser(user)
+        Reservation reservation = reservationRepository.findOngoingReservationByUser(user)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NO_RESERVATION_USER));
 
         validateSameAmount(user, paymentRequest.getAmount());

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/order/service/SharedOrderService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/order/service/SharedOrderService.java
@@ -28,7 +28,7 @@ public class SharedOrderService {
     private final PaymentValidator validator;
 
     public OrderResponse processPayment(User user, PaymentRequest paymentRequest) {
-        Reservation reservation = reservationRepository.findByUser(user)
+        Reservation reservation = reservationRepository.findOngoingReservationByUser(user)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NO_RESERVATION_USER));
         SharedOrder sharedOrder = reservation.getSharedOrder();
         validateSharedCarts(sharedOrder);

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/order/service/SharedOrderService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/order/service/SharedOrderService.java
@@ -10,6 +10,7 @@ import edu.skku.grabtable.order.domain.request.PaymentRequest;
 import edu.skku.grabtable.order.domain.response.OrderResponse;
 import edu.skku.grabtable.order.infrastructure.PaymentValidator;
 import edu.skku.grabtable.order.repository.OrderRepository;
+import edu.skku.grabtable.order.repository.SharedOrderRepository;
 import edu.skku.grabtable.reservation.domain.Reservation;
 import edu.skku.grabtable.reservation.repository.ReservationRepository;
 import edu.skku.grabtable.user.domain.User;
@@ -25,12 +26,14 @@ public class SharedOrderService {
     private final OrderRepository orderRepository;
     private final ReservationRepository reservationRepository;
     private final CartRepository cartRepository;
+    private final SharedOrderRepository sharedOrderRepository;
     private final PaymentValidator validator;
 
     public OrderResponse processPayment(User user, PaymentRequest paymentRequest) {
         Reservation reservation = reservationRepository.findOngoingReservationByUser(user)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NO_RESERVATION_USER));
-        SharedOrder sharedOrder = reservation.getSharedOrder();
+        SharedOrder sharedOrder = sharedOrderRepository.findByReservation(reservation)
+                .orElseThrow();
         validateSharedCarts(sharedOrder);
         validatePayingAmount(paymentRequest.getAmount(), sharedOrder.calculateLeftAmount());
         validator.verify(paymentRequest);
@@ -38,7 +41,7 @@ public class SharedOrderService {
     }
 
     private OrderResponse buildOrderResponse(User user, SharedOrder sharedOrder, int amount) {
-        Order order = new Order(user, sharedOrder, amount);
+        Order order = sharedOrder.addOrder(user, amount);
         orderRepository.save(order);
         return OrderResponse.of(order);
     }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/controller/ReservationController.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/controller/ReservationController.java
@@ -47,7 +47,7 @@ public class ReservationController {
     //select 6개 나감 (TODO)
     @GetMapping("/me")
     public ReservationDetailResponse findCurrentReservation(@AuthUser User user) {
-        return reservationService.findReservationByUser(user);
+        return reservationService.findOngoingReservationByUser(user);
     }
 
     @GetMapping("/me/subscribe")

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/repository/ReservationRepository.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/repository/ReservationRepository.java
@@ -19,10 +19,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query("""
             SELECT r
             FROM Reservation r
-            where r.host = :user
-            or :user MEMBER OF r.invitees
+            where (r.host = :user
+            or :user MEMBER OF r.invitees)
+            and r.status = 'ONGOING'
             """)
-    Optional<Reservation> findByUser(User user);
+    Optional<Reservation> findOngoingReservationByUser(User user);
 
     Optional<Reservation> findByHostId(Long userId);
 

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/service/ReservationService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/service/ReservationService.java
@@ -82,8 +82,8 @@ public class ReservationService {
         userRepository.save(user);
     }
 
-    public ReservationDetailResponse findReservationByUser(User user) {
-        Reservation reservation = reservationRepository.findByUser(user)
+    public ReservationDetailResponse findOngoingReservationByUser(User user) {
+        Reservation reservation = reservationRepository.findOngoingReservationByUser(user)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NO_RESERVATION_USER));
 
         List<OrderResponse> orders = orderRepository.findByReservation(reservation)
@@ -204,14 +204,14 @@ public class ReservationService {
     public void send(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_USER_ID));
-        ReservationDetailResponse reservation = findReservationByUser(user);
+        ReservationDetailResponse reservation = findOngoingReservationByUser(user);
         redisTemplate.convertAndSend(getChannelName(reservation.getId()), reservation);
     }
 
     public SseEmitter createEmitter(User user) {
         Long userId = user.getId();
         SseEmitter emitter = new SseEmitter(10L * 1000 * 60); //10분
-        ReservationDetailResponse reservation = findReservationByUser(user);
+        ReservationDetailResponse reservation = findOngoingReservationByUser(user);
         userEmitters.put(userId, emitter);
 
         try {

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/service/ReservationService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/service/ReservationService.java
@@ -174,14 +174,14 @@ public class ReservationService {
     private void validateMoreThanOneOrderExists(Reservation reservation) {
         if (reservation.getSharedOrder().getOrders().isEmpty() &&
                 orderRepository.findByReservation(reservation).isEmpty()) {
-            throw new BadRequestException(ExceptionCode.NOT_ENOUGH_ORDER);
+            throw new BadRequestException(ExceptionCode.NO_ORDER_FOUND_IN_RESERVATION);
         }
     }
 
     private void validateSharedOrderIsFullyPaid(Reservation reservation) {
         SharedOrder sharedOrder = reservation.getSharedOrder();
         if (sharedOrder.calculateLeftAmount() > 0) {
-            throw new BadRequestException(ExceptionCode.INVALID_REQUEST);
+            throw new BadRequestException(ExceptionCode.UNPAID_AMOUNT_EXIST);
         }
     }
 

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/service/ReviewService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/service/ReviewService.java
@@ -32,9 +32,6 @@ public class ReviewService {
 
     @Transactional(readOnly = true)
     public List<ReviewResponse> getAllReviewsByUser(Long userId) {
-//        User user = userRepository.findById(userId)
-//                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_USER_ID));
-
         List<Review> reviews = reviewRepository.findByUserId(userId);
 
         return reviews.stream().map(ReviewResponse::of).toList();

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/store/domain/Menu.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/store/domain/Menu.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,4 +38,10 @@ public class Menu extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private MenuStatus status;
 
+    @Builder
+    public Menu(Store store, String menuName, Integer price) {
+        this.store = store;
+        this.menuName = menuName;
+        this.price = price;
+    }
 }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/store/domain/Store.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/store/domain/Store.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -52,6 +53,7 @@ public class Store extends BaseTimeEntity {
     @OneToMany(mappedBy = "store")
     private List<Menu> menus = new ArrayList<>();
 
+    @Builder
     public Store(String storeName, String address) {
         this.storeName = storeName;
         this.address = address;

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/integration/OrderCartIntegrationTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/integration/OrderCartIntegrationTest.java
@@ -1,18 +1,94 @@
 package edu.skku.grabtable.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edu.skku.grabtable.cart.service.CartService;
+import edu.skku.grabtable.common.exception.BadRequestException;
+import edu.skku.grabtable.common.exception.ExceptionCode;
+import edu.skku.grabtable.order.domain.request.PaymentRequest;
+import edu.skku.grabtable.order.infrastructure.PaymentValidator;
+import edu.skku.grabtable.order.service.OrderService;
+import edu.skku.grabtable.reservation.service.ReservationService;
+import edu.skku.grabtable.store.domain.Menu;
+import edu.skku.grabtable.store.domain.MenuStatus;
+import edu.skku.grabtable.store.domain.Store;
+import edu.skku.grabtable.store.repository.MenuRepository;
+import edu.skku.grabtable.store.repository.StoreRepository;
+import edu.skku.grabtable.user.domain.User;
+import edu.skku.grabtable.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
 public class OrderCartIntegrationTest {
 
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private CartService cartService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private MenuRepository menuRepository;
+
+    @MockBean
+    PaymentValidator paymentValidator;
+
     @Test
-    @DisplayName("사용자가 주문을 생성한 직후 user.getCart()는 빈 리스트이다.")
+    @DisplayName("개인 주문 결제를 완료한 이후 사용자의 장바구니를 비운다.")
     void verifyDisconnectionBetweenUserAndCarts() {
-        //OrderService.create()의 로직을 그대로 옮겨적고
-        //PaymentValidator를 제외시킨다 (외부 종속성 테스트 불가)
+        User user = new User("userA", "pw", "email", "phone");
+        Store store = new Store("storeA", "addr");
+        Menu menu = new Menu(null, store, "menuA", 1000, null, MenuStatus.VALID);
+
+        userRepository.save(user);
+        storeRepository.save(store);
+        menuRepository.saveAndFlush(menu);
+        
+        reservationService.createNewReservation(user, store.getId());
+        cartService.createCart(user, menu.getId(), 10);
+
+        PaymentRequest paymentRequest = new PaymentRequest("1", 10000);
+        orderService.processPayment(user, paymentRequest);
+
+        assertThat(cartService.findMyCarts(user.getId())).isEmpty();
     }
+
+    @Test
+    @DisplayName("개인 주문 결제 시 결제 요청 금액과 장바구니 금액이 일치하지 않으면 예외가 발생한다.")
+    void isNotSame_paymentRequestAmount_and_cartAmount_then_exception() {
+        User user = new User("userA", "pw", "email", "phone");
+        Store store = new Store("storeA", "addr");
+        Menu menu = new Menu(null, store, "menuA", 1000, null, MenuStatus.VALID);
+
+        userRepository.save(user);
+        storeRepository.save(store);
+        menuRepository.save(menu);
+
+        reservationService.createNewReservation(user, store.getId());
+        cartService.createCart(user, menu.getId(), 10);
+
+        PaymentRequest paymentRequest = new PaymentRequest("1", 5000);
+
+        assertThatThrownBy(() -> orderService.processPayment(user, paymentRequest))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(ExceptionCode.INVALID_PAY_AMOUNT.getMessage());
+    }
+
+
 }

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/integration/OrderConcurrencyTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/integration/OrderConcurrencyTest.java
@@ -1,0 +1,134 @@
+package edu.skku.grabtable.integration;
+
+import edu.skku.grabtable.cart.service.CartService;
+import edu.skku.grabtable.order.domain.Order;
+import edu.skku.grabtable.order.domain.request.PaymentRequest;
+import edu.skku.grabtable.order.infrastructure.PaymentValidator;
+import edu.skku.grabtable.order.repository.OrderRepository;
+import edu.skku.grabtable.order.service.OrderService;
+import edu.skku.grabtable.reservation.domain.Reservation;
+import edu.skku.grabtable.reservation.repository.ReservationRepository;
+import edu.skku.grabtable.reservation.service.ReservationService;
+import edu.skku.grabtable.store.domain.Menu;
+import edu.skku.grabtable.store.domain.MenuStatus;
+import edu.skku.grabtable.store.domain.Store;
+import edu.skku.grabtable.store.repository.MenuRepository;
+import edu.skku.grabtable.store.repository.StoreRepository;
+import edu.skku.grabtable.user.domain.User;
+import edu.skku.grabtable.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class OrderConcurrencyTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private CartService cartService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private MenuRepository menuRepository;
+
+    @MockBean
+    PaymentValidator paymentValidator;
+
+    @AfterEach
+    void tearDown() {
+        //동시성 제어 시 테스트 스레드 이외의 스레드에서 로직을 실행함.
+        //다른 스레드에서는 Rollback 적용이 안되므로, 직접 DB를 복구
+        em.createQuery("delete from Cart c").executeUpdate();
+        em.createQuery("delete from Order o").executeUpdate();
+        em.createQuery("delete from Reservation r").executeUpdate();
+        em.createQuery("delete from Menu m").executeUpdate();
+        em.createQuery("delete from Store s").executeUpdate();
+        em.createQuery("delete from User u").executeUpdate();
+    }
+
+    @Test
+    @DisplayName("사용자가 결제를 여러 번 시도해도 주문은 한 번만 생성된다.")
+    @Rollback(value = false)
+        //TODO
+    void verifySingleOrderCreation() throws InterruptedException, ExecutionException {
+        //동시 주문 생성 요청
+        int nThreads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(nThreads);
+        CountDownLatch latch = new CountDownLatch(nThreads);
+
+        final User findUser = executorService.submit(() -> {
+            Store store = new Store("storeA", "addr");
+            Menu menuA = new Menu(null, store, "menuA", 10000, null, MenuStatus.VALID);
+            Menu menuB = new Menu(null, store, "menuB", 10000, null, MenuStatus.VALID);
+            storeRepository.saveAndFlush(store);
+            menuRepository.saveAndFlush(menuA);
+            menuRepository.saveAndFlush(menuB);
+
+            User user = new User("userA", "pw", "email", "phone");
+            userRepository.saveAndFlush(user);
+
+            //예약 생성
+            reservationService.createNewReservation(user, store.getId());
+            Reservation reservation = reservationRepository.findByUser(user).orElseThrow();
+
+            //장바구니 추가 (총금액 10000원)
+            cartService.createCart(user, menuA.getId(), 1);
+            cartService.createCart(user, menuB.getId(), 1);
+            return user;
+        }).get();
+
+        PaymentRequest paymentRequest = new PaymentRequest("1", 20000);
+
+        for (int i = 0; i < nThreads; i++) {
+            executorService.execute(() -> {
+                try {
+                    orderService.processPayment(findUser, paymentRequest);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        List<Order> orders = em.createQuery("select o from Order o where o.user = :user", Order.class)
+                .setParameter("user", findUser)
+                .getResultList();
+
+//        assertThat(orders.size()).isEqualTo(1);
+
+    }
+}

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/integration/OrderConcurrencyTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/integration/OrderConcurrencyTest.java
@@ -100,7 +100,7 @@ public class OrderConcurrencyTest {
 
             //예약 생성
             reservationService.createNewReservation(user, store.getId());
-            Reservation reservation = reservationRepository.findByUser(user).orElseThrow();
+            Reservation reservation = reservationRepository.findOngoingReservationByUser(user).orElseThrow();
 
             //장바구니 추가 (총금액 10000원)
             cartService.createCart(user, menuA.getId(), 1);

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/integration/ReservationIntegrationTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/integration/ReservationIntegrationTest.java
@@ -1,37 +1,273 @@
 package edu.skku.grabtable.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edu.skku.grabtable.cart.service.CartService;
+import edu.skku.grabtable.common.exception.BadRequestException;
+import edu.skku.grabtable.common.exception.ExceptionCode;
+import edu.skku.grabtable.order.domain.request.PaymentRequest;
+import edu.skku.grabtable.order.infrastructure.PaymentValidator;
+import edu.skku.grabtable.order.repository.OrderRepository;
+import edu.skku.grabtable.order.service.OrderService;
+import edu.skku.grabtable.order.service.SharedOrderService;
+import edu.skku.grabtable.reservation.repository.ReservationRepository;
+import edu.skku.grabtable.reservation.service.ReservationService;
+import edu.skku.grabtable.store.domain.Menu;
+import edu.skku.grabtable.store.domain.Store;
+import edu.skku.grabtable.store.repository.MenuRepository;
+import edu.skku.grabtable.store.repository.StoreRepository;
+import edu.skku.grabtable.user.domain.User;
+import edu.skku.grabtable.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
 public class ReservationIntegrationTest {
 
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ReservationService reservationService;
+
+    @Autowired
+    StoreRepository storeRepository;
+
+    @Autowired
+    MenuRepository menuRepository;
+
+    @Autowired
+    ReservationRepository reservationRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    CartService cartService;
+
+    @Autowired
+    OrderService orderService;
+
+    @Autowired
+    OrderRepository orderRepository;
+
+    @Autowired
+    SharedOrderService sharedOrderService;
+
+    @MockBean
+    PaymentValidator validator;
+
     @Test
     @DisplayName("호스트가 예약을 취소하면 예약의 모든 참여자의 예약 상태가 취소된다.")
     void host_cancel_propagate() {
+        //given
+        User host = User.builder()
+                .username("host")
+                .build();
+
+        User userA = User.builder()
+                .username("userA")
+                .build();
+
+        Store store = new Store("storeA", "addr");
+
+        userRepository.save(host);
+        userRepository.save(userA);
+        storeRepository.save(store);
+
+        reservationService.createNewReservation(host, store.getId());
+        String inviteCode = reservationService.findOngoingReservationByUser(host).getInviteCode();
+        reservationService.joinExistingReservation(userA, inviteCode);
+
+        //when
+        reservationService.cancel(host);
+
+        //then
+        assertThatThrownBy(() -> reservationService.findOngoingReservationByUser(host))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(ExceptionCode.NO_RESERVATION_USER.getMessage());
+
+        assertThatThrownBy(() -> reservationService.findOngoingReservationByUser(userA))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(ExceptionCode.NO_RESERVATION_USER.getMessage());
     }
 
     @Test
-    @DisplayName("참여자가 예약을 취소하면 예약의 참여자가 1명 줄어든 상태로 유지된다.")
+    @DisplayName("호스트가 아닌 참여자가 예약을 취소하면 해당 참여자는 예약에서 빠지고, 예약은 유지된다.")
     void invitee_cancel_remain() {
+        //given
+        User host = User.builder()
+                .username("host")
+                .build();
+
+        User userA = User.builder()
+                .username("userA")
+                .build();
+
+        Store store = Store.builder()
+                .storeName("storeA")
+                .build();
+
+        userRepository.save(host);
+        userRepository.save(userA);
+        storeRepository.save(store);
+
+        reservationService.createNewReservation(host, store.getId());
+        String inviteCode = reservationService.findOngoingReservationByUser(host).getInviteCode();
+        reservationService.joinExistingReservation(userA, inviteCode);
+
+        //when
+        reservationService.cancel(userA);
+
+        //then
+        assertThat(reservationService.findOngoingReservationByUser(host)).isNotNull();
+
+        assertThatThrownBy(() -> reservationService.findOngoingReservationByUser(userA))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(ExceptionCode.NO_RESERVATION_USER.getMessage());
     }
 
     @Test
     @DisplayName("모든 참여자가 주문 완료 상태라면 예약 확정에 성공한다.")
     void confirm_reservation() {
+        //given
+        User host = User.builder()
+                .username("host")
+                .build();
+
+        User userA = User.builder()
+                .username("userA")
+                .build();
+
+        Store store = Store.builder()
+                .storeName("storeA")
+                .build();
+
+        int menuPrice = 1000;
+
+        Menu menuA = Menu.builder()
+                .store(store)
+                .menuName("menuA")
+                .price(menuPrice)
+                .build();
+
+        userRepository.save(host);
+        userRepository.save(userA);
+        storeRepository.save(store);
+        menuRepository.save(menuA);
+
+        reservationService.createNewReservation(host, store.getId());
+        String inviteCode = reservationService.findOngoingReservationByUser(host).getInviteCode();
+        reservationService.joinExistingReservation(userA, inviteCode);
+
+        cartService.createCart(host, menuA.getId(), 1);
+        cartService.createCart(userA, menuA.getId(), 1);
+
+        //when
+        orderService.processPayment(host, new PaymentRequest("1", menuPrice));
+        orderService.processPayment(userA, new PaymentRequest("1", menuPrice));
+
+        //then
+        reservationService.confirmCurrentReservation(host);
     }
 
     @Test
-    @DisplayName("유저 ID로 예약 찾을 시 현재 예약 정보를 확인할 수 있다.")
-    void findReservationDetailInfo() {
+    @DisplayName("예약에서 결제된 공유 주문과 개인 주문의 개수 합이 0개라면 예약 확정에 실패한다.")
+    void if_allOrdersCountIsZero_then_confirmReservation_fail() {
+        //given
+        User host = User.builder()
+                .username("host")
+                .build();
+
+        User userA = User.builder()
+                .username("userA")
+                .build();
+
+        Store store = Store.builder()
+                .storeName("storeA")
+                .build();
+
+        int menuPrice = 1000;
+
+        Menu menuA = Menu.builder()
+                .store(store)
+                .menuName("menuA")
+                .price(menuPrice)
+                .build();
+
+        userRepository.save(host);
+        userRepository.save(userA);
+        storeRepository.save(store);
+        menuRepository.save(menuA);
+
+        reservationService.createNewReservation(host, store.getId());
+        String inviteCode = reservationService.findOngoingReservationByUser(host).getInviteCode();
+        reservationService.joinExistingReservation(userA, inviteCode);
+
+        cartService.createCart(host, menuA.getId(), 1);
+        cartService.createCart(userA, menuA.getId(), 1);
+
+        //when & then
+        assertThatThrownBy(() -> reservationService.confirmCurrentReservation(host))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(ExceptionCode.NO_ORDER_FOUND_IN_RESERVATION.getMessage());
+
     }
 
     @Test
     @DisplayName("공유 주문 잔여 금액이 0원이 아니라면 예약 확정에 실패한다.")
-    void confirm_reservation_fail() {
+    void if_sharedOrderLeftAmountIsNotZero_then_confirmReservation_fail() {
+        //given
+        User host = User.builder()
+                .username("host")
+                .build();
+
+        User userA = User.builder()
+                .username("userA")
+                .build();
+
+        Store store = Store.builder()
+                .storeName("storeA")
+                .build();
+
+        int menuPrice = 1000;
+
+        Menu menuA = Menu.builder()
+                .store(store)
+                .menuName("menuA")
+                .price(menuPrice)
+                .build();
+
+        userRepository.save(host);
+        userRepository.save(userA);
+        storeRepository.save(store);
+        menuRepository.save(menuA);
+
+        reservationService.createNewReservation(host, store.getId());
+        String inviteCode = reservationService.findOngoingReservationByUser(host).getInviteCode();
+        reservationService.joinExistingReservation(userA, inviteCode);
+
+        cartService.createCartInSharedOrder(host, menuA.getId(), 1);
+
+        em.flush();
+        em.clear();
+
+        //when
+        //전체 금액의 절반만 결제
+        sharedOrderService.processPayment(host, new PaymentRequest("1", menuPrice / 2));
+
+        //then
+        //예약 확정 시도
+        assertThatThrownBy(() -> reservationService.confirmCurrentReservation(host))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(ExceptionCode.UNPAID_AMOUNT_EXIST.getMessage());
     }
 
 }

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/order/service/OrderServiceTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/order/service/OrderServiceTest.java
@@ -57,7 +57,7 @@ class OrderServiceTest {
         Reservation reservation = new Reservation(1L, user, null, null, null, "code", ReservationStatus.ONGOING);
         PaymentRequest paymentRequest = new PaymentRequest("impUid", 2000);
         //given
-        given(reservationRepository.findByUser(any()))
+        given(reservationRepository.findOngoingReservationByUser(any()))
                 .willReturn(Optional.of(reservation));
         given(cartRepository.findByUserId(any()))
                 .willReturn(List.of(cart));
@@ -78,7 +78,7 @@ class OrderServiceTest {
         PaymentRequest paymentRequest = new PaymentRequest("impUid", 10000);
 
         //given
-        given(reservationRepository.findByUser(any()))
+        given(reservationRepository.findOngoingReservationByUser(any()))
                 .willReturn(Optional.of(reservation));
         given(cartRepository.findByUserId(any()))
                 .willReturn(List.of());

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/order/service/OrderServiceTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/order/service/OrderServiceTest.java
@@ -53,9 +53,9 @@ class OrderServiceTest {
         User user = new User(1L, "kakaoUser", "url", "userA", "1234", "email", "phone", null, new ArrayList<>(),
                 new ArrayList<>());
         Cart cart = new Cart(1L, user, "coke", 2000, null, null, 1);
-        user.getCarts().add(cart);
+        cartRepository.save(cart);
         Reservation reservation = new Reservation(1L, user, null, null, null, "code", ReservationStatus.ONGOING);
-        PaymentRequest paymentRequest = new PaymentRequest("impUid", 10000);
+        PaymentRequest paymentRequest = new PaymentRequest("impUid", 2000);
         //given
         given(reservationRepository.findByUser(any()))
                 .willReturn(Optional.of(reservation));

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/order/service/SharedOrderServiceTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/order/service/SharedOrderServiceTest.java
@@ -15,6 +15,7 @@ import edu.skku.grabtable.order.domain.request.PaymentRequest;
 import edu.skku.grabtable.order.domain.response.OrderResponse;
 import edu.skku.grabtable.order.infrastructure.PaymentValidator;
 import edu.skku.grabtable.order.repository.OrderRepository;
+import edu.skku.grabtable.order.repository.SharedOrderRepository;
 import edu.skku.grabtable.reservation.domain.Reservation;
 import edu.skku.grabtable.reservation.repository.ReservationRepository;
 import edu.skku.grabtable.store.domain.Store;
@@ -43,6 +44,9 @@ class SharedOrderServiceTest {
     ReservationRepository reservationRepository;
 
     @Mock
+    SharedOrderRepository sharedOrderRepository;
+
+    @Mock
     CartRepository cartRepository;
 
     @Mock
@@ -67,6 +71,8 @@ class SharedOrderServiceTest {
 
         given(reservationRepository.findOngoingReservationByUser(any()))
                 .willReturn(Optional.of(reservation));
+        given(sharedOrderRepository.findByReservation(any()))
+                .willReturn(Optional.of(sharedOrder));
         given(cartRepository.findBySharedOrderId(any()))
                 .willReturn(List.of(cart));
 
@@ -112,6 +118,8 @@ class SharedOrderServiceTest {
 
         given(reservationRepository.findOngoingReservationByUser(any()))
                 .willReturn(Optional.of(reservation));
+        given(sharedOrderRepository.findByReservation(any()))
+                .willReturn(Optional.of(sharedOrder));
         given(cartRepository.findBySharedOrderId(any()))
                 .willReturn(List.of(cart));
 

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/order/service/SharedOrderServiceTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/order/service/SharedOrderServiceTest.java
@@ -65,7 +65,7 @@ class SharedOrderServiceTest {
         sharedOrder.getCarts().add(cart);
         PaymentRequest paymentRequest = new PaymentRequest("impUid", 2000);
 
-        given(reservationRepository.findByUser(any()))
+        given(reservationRepository.findOngoingReservationByUser(any()))
                 .willReturn(Optional.of(reservation));
         given(cartRepository.findBySharedOrderId(any()))
                 .willReturn(List.of(cart));
@@ -88,7 +88,7 @@ class SharedOrderServiceTest {
                 new ArrayList<>());
         PaymentRequest paymentRequest = new PaymentRequest("impUid", 2000);
 
-        given(reservationRepository.findByUser(any()))
+        given(reservationRepository.findOngoingReservationByUser(any()))
                 .willReturn(Optional.empty());
 
         //when & then
@@ -110,7 +110,7 @@ class SharedOrderServiceTest {
         Cart cart = new Cart(1L, null, "coke", 2000, null, sharedOrder, 1);
         PaymentRequest paymentRequest = new PaymentRequest("impUid", 20000);
 
-        given(reservationRepository.findByUser(any()))
+        given(reservationRepository.findOngoingReservationByUser(any()))
                 .willReturn(Optional.of(reservation));
         given(cartRepository.findBySharedOrderId(any()))
                 .willReturn(List.of(cart));

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/reservation/controller/ReservationControllerTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/reservation/controller/ReservationControllerTest.java
@@ -14,11 +14,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.skku.grabtable.auth.domain.UserTokens;
+import edu.skku.grabtable.cart.domain.response.CartResponse;
 import edu.skku.grabtable.common.ControllerTest;
+import edu.skku.grabtable.order.domain.response.OrderResponse;
+import edu.skku.grabtable.order.domain.response.SharedOrderResponse;
 import edu.skku.grabtable.reservation.domain.request.ReservationRequest;
 import edu.skku.grabtable.reservation.domain.response.ReservationDetailResponse;
+import edu.skku.grabtable.reservation.domain.response.UserCartsInfoResponse;
 import edu.skku.grabtable.reservation.service.ReservationService;
 import jakarta.servlet.http.Cookie;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -100,8 +105,22 @@ class ReservationControllerTest extends ControllerTest {
     @DisplayName("유저의 현재 예약을 조회할 수 있다.")
     void me() throws Exception {
         //given
-        ReservationDetailResponse response = new ReservationDetailResponse(1L, 1L, null, null,
-                "invite-code", null, null);
+        CartResponse coke = new CartResponse(1L, "coke", 5, 2000, 10000);
+        CartResponse juice = new CartResponse(2L, "juice", 1, 2000, 2000);
+        CartResponse water = new CartResponse(3L, "water", 3, 500, 1500);
+        CartResponse cake = new CartResponse(4L, "cake", 1, 5400, 5400);
+        CartResponse doughnut = new CartResponse(5L, "doughnut", 1, 3900, 3900);
+
+        UserCartsInfoResponse host = new UserCartsInfoResponse(1L, "host", "https://image.url", List.of(cake));
+        UserCartsInfoResponse userA = new UserCartsInfoResponse(2L, "userA", "https://image2.url", List.of(doughnut));
+
+        OrderResponse orderResponse = new OrderResponse(1L, 1L, List.of(coke), 10000, "PAID");
+        OrderResponse orderResponse2 = new OrderResponse(2L, 1L, List.of(juice, water), 3500, "PAID");
+        SharedOrderResponse sharedOrderResponse = new SharedOrderResponse(1L, List.of(coke), List.of(orderResponse),
+                10000, 10000);
+
+        ReservationDetailResponse response = new ReservationDetailResponse(1L, 1L, host, List.of(userA),
+                "invite-code", sharedOrderResponse, List.of(orderResponse2));
         when(reservationService.findOngoingReservationByUser(any()))
                 .thenReturn(response);
 
@@ -123,20 +142,178 @@ class ReservationControllerTest extends ControllerTest {
                                         .type(JsonFieldType.NUMBER)
                                         .description("가게 ID"),
                                 fieldWithPath("host")
-                                        .type(JsonFieldType.NULL)
-                                        .description("호스트 정보"),
+                                        .type(JsonFieldType.OBJECT)
+                                        .description("호스트 사용자 및 장바구니 정보"),
                                 fieldWithPath("invitees")
-                                        .type(JsonFieldType.NULL)
-                                        .description("참여자들 정보"),
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("예약 참여자들 사용자 및 장바구니 정보"),
                                 fieldWithPath("inviteCode")
                                         .type(JsonFieldType.STRING)
                                         .description("초대 코드"),
                                 fieldWithPath("sharedOrder")
-                                        .type(JsonFieldType.NULL)
+                                        .type(JsonFieldType.OBJECT)
                                         .description("공유 주문 정보"),
                                 fieldWithPath("orders")
-                                        .type(JsonFieldType.NULL)
-                                        .description("개인별 주문 정보")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("개인별 주문 정보"),
+
+                                fieldWithPath("host.id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("호스트 유저 ID"),
+                                fieldWithPath("host.username")
+                                        .type(JsonFieldType.STRING)
+                                        .description("호스트 유저 이름"),
+                                fieldWithPath("host.profileImageUrl")
+                                        .type(JsonFieldType.STRING)
+                                        .description("호스트 프로필 사진 URL"),
+                                fieldWithPath("host.currentCarts")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("호스트의 현재 장바구니"),
+
+                                fieldWithPath("host.currentCarts[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("호스트의 현재 장바구니에 담긴 카트 ID"),
+                                fieldWithPath("host.currentCarts[].menuName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("호스트의 현재 장바구니에 담긴 카트명"),
+                                fieldWithPath("host.currentCarts[].quantity")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("호스트의 현재 장바구니에 담긴 카트 수량"),
+                                fieldWithPath("host.currentCarts[].price")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("호스트의 현재 장바구니에 담긴 카트의 단일 가격"),
+                                fieldWithPath("host.currentCarts[].totalPrice")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("호스트의 현재 장바구니에 담긴 상품의 수량과 단일 가격을 곱한 가격"),
+
+                                fieldWithPath("invitees[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("참가자 유저 ID"),
+                                fieldWithPath("invitees[].username")
+                                        .type(JsonFieldType.STRING)
+                                        .description("참가자 유저 이름"),
+                                fieldWithPath("invitees[].profileImageUrl")
+                                        .type(JsonFieldType.STRING)
+                                        .description("참가자 프로필 사진 URL"),
+                                fieldWithPath("invitees[].currentCarts")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("참가자의 현재 장바구니"),
+                                fieldWithPath("invitees[].currentCarts")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("참가자의 현재 장바구니"),
+
+                                fieldWithPath("invitees[].currentCarts[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("참가자의 현재 장바구니에 담긴 카트 ID"),
+                                fieldWithPath("invitees[].currentCarts[].menuName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("참가자의 현재 장바구니에 담긴 카트 상품명"),
+                                fieldWithPath("invitees[].currentCarts[].quantity")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("참가자의 현재 장바구니에 담긴 카트 상품 수량"),
+                                fieldWithPath("invitees[].currentCarts[].price")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("참가자의 현재 장바구니에 담긴 카트 상품의 단일 가격"),
+                                fieldWithPath("invitees[].currentCarts[].totalPrice")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("참가자의 현재 장바구니에 담긴 카트 상품의 수량과 단일 가격을 곱한 가격"),
+
+                                fieldWithPath("sharedOrder.id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("예약에 할당된 공유 주문 ID"),
+                                fieldWithPath("sharedOrder.carts")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("공유 주문의 장바구니"),
+                                fieldWithPath("sharedOrder.orders")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("공유 주문에 대해 완료된 결제들"),
+                                fieldWithPath("sharedOrder.totalAmount")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문의 총 금액"),
+                                fieldWithPath("sharedOrder.leftAmount")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문의 미결제 금액"),
+
+                                fieldWithPath("sharedOrder.carts[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문 장바구니에 있는 카트 ID"),
+                                fieldWithPath("sharedOrder.carts[].menuName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("공유 주문 장바구니에 있는 카트 상품명"),
+                                fieldWithPath("sharedOrder.carts[].quantity")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문 장바구니에 있는 카트 상품 수량"),
+                                fieldWithPath("sharedOrder.carts[].price")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문 장바구니에 있는 카트 상품의 단일 가격"),
+                                fieldWithPath("sharedOrder.carts[].totalPrice")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문 장바구니에 있는 카트 상품의 전체 가격"),
+
+                                fieldWithPath("sharedOrder.orders[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문에 있는 결제 완료된 주문의 ID"),
+                                fieldWithPath("sharedOrder.orders[].userId")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문에 있는 결제 완료된 주문을 결제한 사용자의 ID"),
+                                fieldWithPath("sharedOrder.orders[].carts")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("공유 주문에 있는 결제 완료된 주문의 카트 리스트"),
+                                fieldWithPath("sharedOrder.orders[].paidAmount")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문에 있는 결제 완료된 주문의 결제된 금액"),
+                                fieldWithPath("sharedOrder.orders[].status")
+                                        .type(JsonFieldType.STRING)
+                                        .description("공유 주문에 있는 결제 완료된 주문의 결제 완료 여부"),
+
+                                fieldWithPath("sharedOrder.orders[].carts[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문에 있는 결제 완료된 주문의 단일 카트 ID"),
+                                fieldWithPath("sharedOrder.orders[].carts[].menuName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("공유 주문에 있는 결제 완료된 주문의 단일 카트 상품명"),
+                                fieldWithPath("sharedOrder.orders[].carts[].quantity")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문에 있는 결제 완료된 주문의 단일 카트 상품 수량"),
+                                fieldWithPath("sharedOrder.orders[].carts[].price")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문에 있는 결제 완료된 주문의 단일 카트 상품 가격"),
+                                fieldWithPath("sharedOrder.orders[].carts[].totalPrice")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공유 주문에 있는 결제 완료된 주문의 단일 카트 상품 전체 가격"),
+
+                                fieldWithPath("orders[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("결제된 개인 주문의 ID"),
+                                fieldWithPath("orders[].userId")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("결제된 개인 주문을 결제한 사용자의 ID"),
+                                fieldWithPath("orders[].carts")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("결제된 개인 주문의 카트 리스트"),
+                                fieldWithPath("orders[].paidAmount")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("개인 주문의 결제된 금액"),
+                                fieldWithPath("orders[].status")
+                                        .type(JsonFieldType.STRING)
+                                        .description("결제된 개인 주문의 결제 완료 여부"),
+
+                                fieldWithPath("orders[].carts[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("결제된 개인 주문의 단일 카트 ID"),
+                                fieldWithPath("orders[].carts[].menuName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("결제된 개인 주문의 단일 카트 상품명"),
+                                fieldWithPath("orders[].carts[].quantity")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("결제된 개인 주문의 단일 카트 상품 수량"),
+                                fieldWithPath("orders[].carts[].price")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("결제된 개인 주문의 단일 카트 상품 가격"),
+                                fieldWithPath("orders[].carts[].totalPrice")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("결제된 개인 주문의 단일 카트 상품 전체 가격")
+
                         )
                 )
         ).andReturn();

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/reservation/controller/ReservationControllerTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/reservation/controller/ReservationControllerTest.java
@@ -102,7 +102,7 @@ class ReservationControllerTest extends ControllerTest {
         //given
         ReservationDetailResponse response = new ReservationDetailResponse(1L, 1L, null, null,
                 "invite-code", null, null);
-        when(reservationService.findReservationByUser(any()))
+        when(reservationService.findOngoingReservationByUser(any()))
                 .thenReturn(response);
 
         //when


### PR DESCRIPTION
### Type of Issue

<!-- 
이슈 번호와 간단한 설명을 적어주세요. 
resolve #<이슈번호> 넣으면 PR close시 자동으로 이슈도 close 됩니다.
ex. resolve #1
-->

resolve #45 

### Key Change

<!-- 핵심 변화를 나열해주세요. -->

- `/v1/reservations/me` API의 응답 형식이 더 자세하게 Rest Docs에서 나타납니다.
- 여러 서비스 로직에서 사용되는 `reservationRepository.findByUser()` 메소드명이 `findOngoingReservationByUser()`로 변경되고, 현재 진행 중인 예약만을 반환합니다.
- 테스트 용이성을 위해 일부 도메인 생성자에 `@Builder` 어노테이션이 추가됩니다. 
- `reservation.getSharedOrder()` 대신 `SharedOrderRepository.findByReservation()`를 통해 `SharedOrder`에 접근하여, 객체 그래프 탐색에서 반대 방향 관계를 수정&삭제를 시도하려는 실수를 방지합니다.
- 예약, 주문 관련 통합 테스트가 추가됩니다.
- 주문 동시성 테스트가 임시로 추가됩니다. (동시성 제어 로직 구현 필요)