### PR TITLE
Feature(be): JPA 쿼리 횟수 로깅 추가

### DIFF
--- a/backend/grabtable/build.gradle
+++ b/backend/grabtable/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/common/config/HibernateConfig.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/common/config/HibernateConfig.java
@@ -1,0 +1,21 @@
+package edu.skku.grabtable.common.config;
+
+import edu.skku.grabtable.common.inspector.QueryCountInspector;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.cfg.AvailableSettings;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class HibernateConfig {
+
+    private final QueryCountInspector queryCountInspector;
+
+    @Bean
+    public HibernatePropertiesCustomizer configureStatementInspector() {
+        return hibernateProperties ->
+                hibernateProperties.put(AvailableSettings.STATEMENT_INSPECTOR, queryCountInspector);
+    }
+}

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/common/config/WebConfig.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/common/config/WebConfig.java
@@ -1,11 +1,13 @@
 package edu.skku.grabtable.common.config;
 
 import edu.skku.grabtable.auth.AuthUserArgumentResolver;
+import edu.skku.grabtable.common.interceptor.QueryLoggingInterceptor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @RequiredArgsConstructor
@@ -13,6 +15,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private final AuthUserArgumentResolver authUserArgumentResolver;
+    private final QueryLoggingInterceptor queryLoggingInterceptor;
 
     @Override
     public void addCorsMappings(CorsRegistry corsRegistry) {
@@ -26,5 +29,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
         argumentResolvers.add(authUserArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(queryLoggingInterceptor)
+                .excludePathPatterns("/css/**", "/images/**", "/js/**");
     }
 }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/common/inspector/QueryCountInspector.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/common/inspector/QueryCountInspector.java
@@ -1,0 +1,49 @@
+package edu.skku.grabtable.common.inspector;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QueryCountInspector implements StatementInspector {
+
+    private final ThreadLocal<QueryCounter> queryCounter = new ThreadLocal<>();
+
+    @Override
+    public String inspect(String sql) {
+        QueryCounter counter = queryCounter.get();
+        if (counter != null) {
+            counter.increaseCount();
+        }
+        return sql;
+    }
+
+    public void startCounter() {
+        queryCounter.set(new QueryCounter(0L, System.currentTimeMillis()));
+    }
+
+    public void clearCounter() {
+        queryCounter.remove();
+    }
+
+    public Long getCount() {
+        return queryCounter.get().getCount();
+    }
+
+    public Long getTimeStamp() {
+        return queryCounter.get().getTimestamp();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    static class QueryCounter {
+
+        private Long count;
+        private Long timestamp;
+
+        public void increaseCount() {
+            count++;
+        }
+    }
+}

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/common/interceptor/QueryLoggingInterceptor.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/common/interceptor/QueryLoggingInterceptor.java
@@ -1,0 +1,50 @@
+package edu.skku.grabtable.common.interceptor;
+
+import edu.skku.grabtable.common.inspector.QueryCountInspector;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class QueryLoggingInterceptor implements HandlerInterceptor {
+
+    private static final int WARNING_THRESHOLD = 5;
+
+    private final QueryCountInspector queryCountInspector;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        queryCountInspector.startCounter();
+        return HandlerInterceptor.super.preHandle(request, response, handler);
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+            throws Exception {
+        Long queryCount = queryCountInspector.getCount();
+        double time = getQueryElapsedSeconds();
+
+        log.info("상태코드: {}, 메소드: {}, URI: {}, 쿼리 횟수: {}, 경과 시간: {}초",
+                response.getStatus(),
+                request.getMethod(),
+                request.getRequestURI(),
+                queryCount,
+                time);
+
+        if (queryCount >= WARNING_THRESHOLD) {
+            log.warn("쿼리 횟수 {}회 초과 : {}", WARNING_THRESHOLD, queryCount);
+        }
+
+        queryCountInspector.clearCounter();
+    }
+
+    private double getQueryElapsedSeconds() {
+        return (System.currentTimeMillis() - queryCountInspector.getTimeStamp()) / 1000.0;
+    }
+}

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/common/ControllerTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/common/ControllerTest.java
@@ -1,9 +1,13 @@
 package edu.skku.grabtable.common;
 
+import static org.mockito.ArgumentMatchers.any;
+
 import edu.skku.grabtable.auth.AuthUserArgumentResolver;
 import edu.skku.grabtable.common.config.RestDocsConfiguration;
+import edu.skku.grabtable.common.interceptor.QueryLoggingInterceptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -27,16 +31,22 @@ public abstract class ControllerTest {
     @MockBean
     protected AuthUserArgumentResolver authUserArgumentResolver;
 
+    @MockBean
+    protected QueryLoggingInterceptor queryLoggingInterceptor;
+
     @Autowired
     protected RestDocumentationResultHandler restDocs;
 
     @BeforeEach
-    void setUp(WebApplicationContext context, RestDocumentationContextProvider restDoc) {
+    void setUp(WebApplicationContext context, RestDocumentationContextProvider restDoc) throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
                 .apply(MockMvcRestDocumentation.documentationConfiguration(restDoc))
                 .alwaysDo(MockMvcResultHandlers.print())
                 .alwaysDo(restDocs)
                 .addFilter(new CharacterEncodingFilter("UTF-8", true))
                 .build();
+
+        Mockito.when(queryLoggingInterceptor.preHandle(any(), any(), any()))
+                .thenReturn(true);
     }
 }

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/common/inspector/QueryCountInspectorTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/common/inspector/QueryCountInspectorTest.java
@@ -1,0 +1,27 @@
+package edu.skku.grabtable.common.inspector;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class QueryCountInspectorTest {
+
+    @Autowired
+    private QueryCountInspector queryCountInspector;
+
+    @Test
+    @DisplayName("JPA에 의해 inspect 메소드가 호출되면 SQL 쿼리 counter가 증가한다.")
+    void inspect() {
+        // given
+        queryCountInspector.startCounter();
+
+        // when
+        queryCountInspector.inspect("test query");
+
+        // then
+        Assertions.assertThat(queryCountInspector.getCount()).isOne();
+    }
+}

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/common/interceptor/QueryLoggingInterceptorTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/common/interceptor/QueryLoggingInterceptorTest.java
@@ -1,0 +1,100 @@
+package edu.skku.grabtable.common.interceptor;
+
+import static org.mockito.Mockito.doNothing;
+
+import edu.skku.grabtable.common.inspector.QueryCountInspector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@ExtendWith(MockitoExtension.class)
+class QueryLoggingInterceptorTest {
+
+    private MockHttpServletRequest mockHttpServletRequest;
+
+    @Mock
+    private QueryCountInspector queryCountInspector;
+
+    @InjectMocks
+    private QueryLoggingInterceptor queryLoggingInterceptor;
+
+    @BeforeEach
+    void setUp() {
+        mockHttpServletRequest = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(mockHttpServletRequest));
+    }
+
+    @Test
+    @DisplayName("preHandle 단계에서 queryCountInspector.startCounter()가 호출된다.")
+    void preHandle() throws Exception {
+        //given
+        doNothing()
+                .when(queryCountInspector).startCounter();
+
+        // when
+        queryLoggingInterceptor.preHandle(mockHttpServletRequest, null, null);
+
+        // then
+        Mockito.verify(queryCountInspector).startCounter();
+    }
+
+    @Test
+    @DisplayName("afterCompletion 단계에서 queryCountInspector의 값을 가져와 로그에 출력한다.")
+    void afterCompletion() throws Exception {
+        //given
+        doNothing()
+                .when(queryCountInspector).clearCounter();
+        Mockito.when(queryCountInspector.getCount()).thenReturn(1L);
+        Mockito.when(queryCountInspector.getTimeStamp()).thenReturn(0L);
+
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        mockHttpServletResponse.setStatus(200);
+
+        // when
+        queryLoggingInterceptor.afterCompletion(
+                mockHttpServletRequest,
+                mockHttpServletResponse,
+                null,
+                null
+        );
+
+        // then
+        Mockito.verify(queryCountInspector).getCount();
+        Mockito.verify(queryCountInspector).getTimeStamp();
+    }
+
+    @Test
+    @DisplayName("쿼리 횟수가 임계치 이상 시 경고 로그를 출력한다.")
+    void afterCompletion_log_warn() throws Exception {
+        //given
+        doNothing()
+                .when(queryCountInspector).clearCounter();
+        Mockito.when(queryCountInspector.getCount()).thenReturn(100000L);
+        Mockito.when(queryCountInspector.getTimeStamp()).thenReturn(0L);
+
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        mockHttpServletResponse.setStatus(200);
+
+        // when
+        queryLoggingInterceptor.afterCompletion(
+                mockHttpServletRequest,
+                mockHttpServletResponse,
+                null,
+                null
+        );
+
+        // then
+        Mockito.verify(queryCountInspector).getCount();
+        Mockito.verify(queryCountInspector).getTimeStamp();
+    }
+
+}


### PR DESCRIPTION
### Type of Issue

<!-- 
이슈 번호와 간단한 설명을 적어주세요. 
resolve #<이슈번호> 넣으면 PR close시 자동으로 이슈도 close 됩니다.
ex. resolve #1
-->
resolve #124 

### Key Change

- 이제 서버 실행 시 JPA에서 생성한 DB 쿼리 개수가 로그로 출력됩니다.
- 예시 동작

```
2024-07-06T18:31:44.168+09:00  INFO 75758 --- [nio-8000-exec-1] e.s.g.c.i.QueryLoggingInterceptor        : 상태코드: 200, 메소드: GET, URI: /v1/stores, 쿼리 횟수: 7, 경과 시간: 0.397초
2024-07-06T18:31:44.168+09:00  WARN 75758 --- [nio-8000-exec-1] e.s.g.c.i.QueryLoggingInterceptor        : 쿼리 횟수 5회 초과 : 7
```
<!-- 핵심 변화를 나열해주세요. -->