### PR TITLE
Test(be): api endpoint별 JPA 쿼리 카운팅 테스트 추가

### DIFF
--- a/backend/grabtable/src/docs/asciidoc/review-controller-test.adoc
+++ b/backend/grabtable/src/docs/asciidoc/review-controller-test.adoc
@@ -1,6 +1,6 @@
 == ReviewController
 
-=== 유저의 모든 리뷰 조회 (GET /v1/reviews/\{userId\})
+=== 유저의 모든 리뷰 조회 (GET /v1/reviews/users/\{userId\})
 
 ==== 요청
 
@@ -10,7 +10,7 @@ include::{snippets}/review-controller-test/get-all-reviews-by-user-id/http-reque
 
 include::{snippets}/review-controller-test/get-all-reviews-by-user-id/http-response.adoc[]
 
-=== 가게의 모든 리뷰 조회 (GET /v1/reviews/\{storeId\})
+=== 가게의 모든 리뷰 조회 (GET /v1/reviews/stores/\{storeId\})
 
 ==== 요청
 

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/order/controller/OrderController.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/order/controller/OrderController.java
@@ -7,6 +7,8 @@ import edu.skku.grabtable.order.service.OrderService;
 import edu.skku.grabtable.user.domain.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,11 +22,12 @@ public class OrderController {
     private final OrderService orderService;
 
     @PostMapping
-    public OrderResponse processPayment(
+    public ResponseEntity<OrderResponse> processPayment(
             @AuthUser User user,
             @Valid @RequestBody PaymentRequest paymentRequest
     ) {
-        return orderService.processPayment(user, paymentRequest);
+        OrderResponse orderResponse = orderService.processPayment(user, paymentRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(orderResponse);
     }
 
 }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/order/controller/SharedOrderController.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/order/controller/SharedOrderController.java
@@ -7,6 +7,8 @@ import edu.skku.grabtable.order.service.SharedOrderService;
 import edu.skku.grabtable.user.domain.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,10 +21,11 @@ public class SharedOrderController {
     private final SharedOrderService sharedOrderService;
 
     @PostMapping
-    public OrderResponse processPayment(
+    public ResponseEntity<OrderResponse> processPayment(
             @AuthUser User user,
             @Valid @RequestBody PaymentRequest paymentRequest
     ) {
-        return sharedOrderService.processPayment(user, paymentRequest);
+        OrderResponse orderResponse = sharedOrderService.processPayment(user, paymentRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(orderResponse);
     }
 }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/aop/ReservationAspect.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/aop/ReservationAspect.java
@@ -25,10 +25,13 @@ public class ReservationAspect {
     public void cartControllerUpdateMethods() {
     }
 
-    @Pointcut("execution(* edu.skku.grabtable.reservation.controller.ReservationController.join(..)) || " +
-            "execution(* edu.skku.grabtable.reservation.controller.ReservationController.confirm(..)) || " +
-            "execution(* edu.skku.grabtable.reservation.controller.ReservationController.cancelReservation(..))")
+    @Pointcut("execution(* edu.skku.grabtable.reservation.controller.ReservationController.join(..))")
     public void reservationControllerUpdateMethods() {
+    }
+
+    @Pointcut("execution(* edu.skku.grabtable.reservation.controller.ReservationController.confirm(..)) || " +
+            "execution(* edu.skku.grabtable.reservation.controller.ReservationController.cancelReservation(..))")
+    public void reservationDestroyMethods() {
     }
 
     @Pointcut("execution(* edu.skku.grabtable.order.controller.OrderController.processPayment(..))")

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/controller/ReservationController.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/controller/ReservationController.java
@@ -9,6 +9,7 @@ import edu.skku.grabtable.user.domain.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -50,7 +51,7 @@ public class ReservationController {
         return reservationService.findOngoingReservationByUser(user);
     }
 
-    @GetMapping("/me/subscribe")
+    @GetMapping(path = "/me/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@AuthUser User user) {
         return reservationService.createEmitter(user);
     }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/service/ReservationService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/service/ReservationService.java
@@ -277,8 +277,6 @@ public class ReservationService {
                     .data(data));
         } catch (IOException e) {
             userEmitters.remove(userId);
-            log.error("SSE 연결 오류 발생, userId={}", userId);
-            throw new RuntimeException(e);
         }
     }
 

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/review/controller/ReviewController.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/review/controller/ReviewController.java
@@ -1,15 +1,17 @@
 package edu.skku.grabtable.review.controller;
 
 import edu.skku.grabtable.auth.annotation.AuthUser;
-import edu.skku.grabtable.user.domain.User;
 import edu.skku.grabtable.review.domain.request.ReviewRequest;
 import edu.skku.grabtable.review.domain.request.ReviewUpdateRequest;
 import edu.skku.grabtable.review.domain.response.ReviewResponse;
 import edu.skku.grabtable.review.domain.response.ReviewSummaryResponse;
 import edu.skku.grabtable.review.service.ReviewService;
+import edu.skku.grabtable.user.domain.User;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -42,27 +44,30 @@ public class ReviewController {
     }
 
     @PostMapping
-    public void upload(
+    public ResponseEntity<Void> upload(
             @AuthUser User user,
             @RequestBody @Valid ReviewRequest request
     ) {
         reviewService.upload(user.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PatchMapping("/{reviewId}")
-    public void update(
+    public ResponseEntity<Void> update(
             @AuthUser User user,
             @RequestBody @Valid ReviewUpdateRequest request,
             @PathVariable Long reviewId
     ) {
         reviewService.update(user.getId(), reviewId, request.getMessage(), request.getRating());
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{reviewId}")
-    public void delete(
+    public ResponseEntity<Void> delete(
             @AuthUser User user,
             @PathVariable Long reviewId
     ) {
         reviewService.delete(user.getId(), reviewId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/user/controller/UserController.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/user/controller/UserController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("v1/user")
+@RequestMapping("/v1/users")
 @RestController
 @RequiredArgsConstructor
 public class UserController {

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/order/controller/OrderControllerTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/order/controller/OrderControllerTest.java
@@ -51,7 +51,7 @@ class OrderControllerTest extends ControllerTest {
                         .cookie(new Cookie("refresh-token", REFRESH_TOKEN))
                         .content(objectMapper.writeValueAsString(paymentRequest)))
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andReturn();
 
         OrderResponse actual = objectMapper.readValue(

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/order/controller/SharedOrderControllerTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/order/controller/SharedOrderControllerTest.java
@@ -52,7 +52,7 @@ class SharedOrderControllerTest extends ControllerTest {
                         .cookie(new Cookie("refresh-token", REFRESH_TOKEN))
                         .content(objectMapper.writeValueAsString(paymentRequest)))
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andReturn();
 
         OrderResponse actual = objectMapper.readValue(

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/CartApiQueryCountTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/CartApiQueryCountTest.java
@@ -1,0 +1,146 @@
+package edu.skku.grabtable.query.count;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.skku.grabtable.auth.JwtUtil;
+import edu.skku.grabtable.auth.domain.UserTokens;
+import edu.skku.grabtable.cart.domain.request.CartCreateRequest;
+import edu.skku.grabtable.cart.domain.request.CartUpdateRequest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql(
+        value = {"classpath:data/users.sql",
+                "classpath:data/stores.sql",
+                "classpath:data/menus.sql",
+                "classpath:data/shared_orders.sql",
+                "classpath:data/reservations.sql",
+                "classpath:data/carts.sql"}
+)
+public class CartApiQueryCountTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("GET /v1/carts/me 쿼리 개수 측정")
+    void countGetV1CartsMe() throws Exception {
+        final UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+
+        mockMvc.perform(get("/v1/carts/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken())))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("POST /v1/carts 쿼리 개수 측정")
+    void countPostV1Carts() throws Exception {
+        final UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+        CartCreateRequest cartCreateRequest = new CartCreateRequest(1L, 1000);
+
+        mockMvc.perform(post("/v1/carts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken()))
+                        .content(objectMapper.writeValueAsString(cartCreateRequest)))
+                .andExpect(status().isCreated())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("PATCH /v1/carts/{cartId} 쿼리 개수 측정")
+    void countPatchV1CartsCartId() throws Exception {
+        final UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+        CartUpdateRequest updateRequest = new CartUpdateRequest(10);
+
+        mockMvc.perform(patch("/v1/carts/{cartId}", 1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken()))
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("DELETE /v1/carts/{cartId} 쿼리 개수 측정")
+    void countDeleteV1CartsCartId() throws Exception {
+        final UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+
+        mockMvc.perform(delete("/v1/carts/{cartId}", 1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken())))
+                .andExpect(status().isNoContent())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("POST /v1/carts/shared 쿼리 개수 측정")
+    void countPostV1CartsShared() throws Exception {
+        final UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+        CartCreateRequest cartCreateRequest = new CartCreateRequest(1L, 1000);
+
+        mockMvc.perform(post("/v1/carts/shared")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken()))
+                        .content(objectMapper.writeValueAsString(cartCreateRequest)))
+                .andExpect(status().isCreated())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("PATCH /v1/carts/shared/{cartId} 쿼리 개수 측정")
+    void countPatchV1CartsSharedCartId() throws Exception {
+        final UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+        CartUpdateRequest updateRequest = new CartUpdateRequest(10);
+
+        mockMvc.perform(patch("/v1/carts/shared/{cartId}", 2)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken()))
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("DELETE /v1/carts/shared/{cartId} 쿼리 개수 측정")
+    void countDeleteV1CartsSharedCartId() throws Exception {
+        final UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+
+        mockMvc.perform(delete("/v1/carts/shared/{cartId}", 2)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken())))
+                .andExpect(status().isNoContent())
+                .andReturn();
+    }
+}

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/OrderApiQueryCountTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/OrderApiQueryCountTest.java
@@ -1,0 +1,67 @@
+package edu.skku.grabtable.query.count;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.skku.grabtable.auth.JwtUtil;
+import edu.skku.grabtable.auth.domain.UserTokens;
+import edu.skku.grabtable.order.domain.request.PaymentRequest;
+import edu.skku.grabtable.order.infrastructure.PaymentValidator;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql(
+        value = {
+                "classpath:data/users.sql",
+                "classpath:data/stores.sql",
+                "classpath:data/shared_orders.sql",
+                "classpath:data/reservations.sql",
+                "classpath:data/orders.sql",
+                "classpath:data/carts.sql"
+        }
+)
+public class OrderApiQueryCountTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private PaymentValidator paymentValidator;
+
+    @Test
+    @DisplayName("POST /v1/orders 쿼리 개수 측정")
+    void countPostV1Orders() throws Exception {
+        UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+
+        //주의: carts.sql 수정 시 테스트 실패할 수 있음
+        PaymentRequest paymentRequest = new PaymentRequest("1000", 5000);
+
+        mockMvc.perform(post("/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken()))
+                        .content(objectMapper.writeValueAsString(paymentRequest)))
+                .andExpect(status().isCreated())
+                .andReturn();
+    }
+}

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/ReservationApiQueryCountTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/ReservationApiQueryCountTest.java
@@ -1,0 +1,131 @@
+package edu.skku.grabtable.query.count;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.skku.grabtable.auth.JwtUtil;
+import edu.skku.grabtable.auth.domain.UserTokens;
+import edu.skku.grabtable.reservation.domain.request.ReservationRequest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql(
+        value = {
+                "classpath:data/users.sql",
+                "classpath:data/stores.sql",
+                "classpath:data/shared_orders.sql",
+                "classpath:data/reservations.sql",
+                "classpath:data/orders.sql"
+        }
+)
+public class ReservationApiQueryCountTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("POST /v1/reservations 쿼리 개수 측정")
+    void countPostV1Reservations() throws Exception {
+        UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(1L));
+        ReservationRequest reservationRequest = new ReservationRequest(1L);
+
+        mockMvc.perform(post("/v1/reservations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken()))
+                        .content(objectMapper.writeValueAsString(reservationRequest)))
+                .andExpect(status().isCreated())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("POST /v1/reservations/{inviteCode} 쿼리 개수 측정")
+    void countPostV1ReservationsInviteCode() throws Exception {
+        UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(1L));
+
+        mockMvc.perform(post("/v1/reservations/{inviteCode}", "testInviteCode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken())))
+                .andExpect(status().isCreated())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("GET /v1/reservations/me 쿼리 개수 측정")
+    void countGetV1ReservationsMe() throws Exception {
+        UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+
+        mockMvc.perform(get("/v1/reservations/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken())))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+//    @Test
+//    @DisplayName("GET /v1/reservations/me/subscribe 쿼리 개수 측정")
+//    void countGetV1ReservationsMeSubscribe() throws Exception {
+//        UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+//
+//        //TODO: 쿼리 개수 출력 X
+//        MvcResult mvcResult = mockMvc.perform(get("/v1/reservations/me/subscribe")
+//                        .contentType(MediaType.TEXT_EVENT_STREAM)
+//                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+//                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken())))
+//                .andExpect(status().isOk())
+//                .andDo(MockMvcResultHandlers.print())
+//                .andReturn();
+//
+//        mvcResult.getResponse().getOutputStream().close();
+//    }
+
+    @Test
+    @DisplayName("POST /v1/reservations/confirm 쿼리 개수 측정")
+    void countPostV1ReservationsConfirm() throws Exception {
+        UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+
+        mockMvc.perform(post("/v1/reservations/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken())))
+                .andExpect(status().isCreated())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("DELETE /v1/reservations 쿼리 개수 측정")
+    void countDeleteV1Reservations() throws Exception {
+        UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+
+        mockMvc.perform(delete("/v1/reservations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken())))
+                .andExpect(status().isNoContent())
+                .andReturn();
+    }
+}
+

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/ReviewApiQueryCountTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/ReviewApiQueryCountTest.java
@@ -1,0 +1,95 @@
+package edu.skku.grabtable.query.count;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.skku.grabtable.auth.JwtUtil;
+import edu.skku.grabtable.auth.domain.UserTokens;
+import edu.skku.grabtable.review.domain.request.ReviewRequest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql(value = {
+        "classpath:data/stores.sql",
+        "classpath:data/reviews.sql",
+        "classpath:data/users.sql"
+})
+public class ReviewApiQueryCountTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Test
+    @DisplayName("GET /v1/reviews/users/{userId} 쿼리 개수 측정")
+    void countGetV1ReviewsUsersUserId() throws Exception {
+        mockMvc.perform(get("/v1/reviews/users/{userId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("GET /v1/reviews/stores/{storeId} 쿼리 개수 측정")
+    void countGetV1ReviewsStoresStoreId() throws Exception {
+        mockMvc.perform(get("/v1/reviews/stores/{storeId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("POST /v1/reviews 쿼리 개수 측정")
+    void countPostV1ReviewsReviewId() throws Exception {
+        ReviewRequest reviewRequest = new ReviewRequest(1L, "message", 5.0);
+        UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(1L));
+        mockMvc.perform(post("/v1/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken()))
+                        .content(objectMapper.writeValueAsString(reviewRequest)))
+                .andExpect(status().isCreated())
+                .andReturn();
+    }
+
+//    @Test
+//    @DisplayName("PATCH /v1/reviews/{reviewId}")
+//    void countPatchV1ReviewsReviewId() throws Exception {
+//        ReviewUpdateRequest updateRequest = new ReviewUpdateRequest("updatedMessage", 5.0);
+//        mockMvc.perform(patch("/v1/reviews/{reviewId}", 1L)
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .content(objectMapper.writeValueAsString(updateRequest)))
+//                .andExpect(status().isCreated())
+//                .andReturn();
+//    }
+
+//    @Test
+//    @DisplayName("DELETE /v1/reviews/{reviewId}")
+//    void countDeleteV1ReviewsReviewId() throws Exception {
+//        mockMvc.perform(delete("/v1/reviews/{reviewId}", 1L)
+//                        .contentType(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isNoContent())
+//                .andReturn();
+//    }
+
+
+}

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/SharedOrderApiQueryCountTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/SharedOrderApiQueryCountTest.java
@@ -1,0 +1,67 @@
+package edu.skku.grabtable.query.count;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.skku.grabtable.auth.JwtUtil;
+import edu.skku.grabtable.auth.domain.UserTokens;
+import edu.skku.grabtable.order.domain.request.PaymentRequest;
+import edu.skku.grabtable.order.infrastructure.PaymentValidator;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql(
+        value = {
+                "classpath:data/users.sql",
+                "classpath:data/stores.sql",
+                "classpath:data/shared_orders.sql",
+                "classpath:data/reservations.sql",
+                "classpath:data/orders.sql",
+                "classpath:data/carts.sql"
+        }
+)
+public class SharedOrderApiQueryCountTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private PaymentValidator paymentValidator;
+
+    @Test
+    @DisplayName("POST /v1/shared-orders 쿼리 개수 측정")
+    void countPostV1SharedOrders() throws Exception {
+        UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(3L));
+
+        //주의: carts.sql 수정 시 테스트 실패할 수 있음
+        PaymentRequest paymentRequest = new PaymentRequest("1000", 100);
+
+        mockMvc.perform(post("/v1/shared-orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken()))
+                        .content(objectMapper.writeValueAsString(paymentRequest)))
+                .andExpect(status().isCreated())
+                .andReturn();
+    }
+}

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/StoreApiQueryCountTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/StoreApiQueryCountTest.java
@@ -1,0 +1,51 @@
+package edu.skku.grabtable.query.count;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql(value = {
+        "classpath:data/stores.sql"
+})
+public class StoreApiQueryCountTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("GET /v1/stores 쿼리 개수 측정")
+    void countGetV1Stores() throws Exception {
+        mockMvc.perform(get("/v1/stores"))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("GET /v1/stores/{storeId} 쿼리 개수 측정")
+    void countGetV1StoresStoreId() throws Exception {
+        mockMvc.perform(get("/v1/stores/{storeId}", 1))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("Get /v1/stores/{storeId}/menus 쿼리 개수 측정")
+    void countGetV1StoresStoreIdMenus() throws Exception {
+        mockMvc.perform(get("/v1/stores/{storeId}/menus", 1))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+
+}

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/UserApiQueryCountTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/query/count/UserApiQueryCountTest.java
@@ -1,0 +1,68 @@
+package edu.skku.grabtable.query.count;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.skku.grabtable.auth.JwtUtil;
+import edu.skku.grabtable.auth.domain.UserTokens;
+import edu.skku.grabtable.user.domain.request.UserUpdateRequest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql(
+        value = "classpath:data/users.sql"
+)
+public class UserApiQueryCountTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+
+    @Test
+    @DisplayName("GET /v1/user/me 쿼리 개수 측정")
+    void countGetV1UserMe() throws Exception {
+        final UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(1L));
+
+        mockMvc.perform(get("/v1/users/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken())))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("PATCH /v1/user 쿼리 개수 측정")
+    void countPatchV1User() throws Exception {
+        final UserTokens loginToken = jwtUtil.createLoginToken(String.valueOf(1L));
+        UserUpdateRequest userUpdateRequest = new UserUpdateRequest("testUrl", "userA", "email", "phone");
+
+        mockMvc.perform(patch("/v1/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + loginToken.getAccessToken())
+                        .cookie(new Cookie("refresh-token", loginToken.getRefreshToken()))
+                        .content(objectMapper.writeValueAsString(userUpdateRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+}

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/review/controller/ReviewControllerTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/review/controller/ReviewControllerTest.java
@@ -6,12 +6,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.skku.grabtable.common.ControllerTest;
-import edu.skku.grabtable.user.domain.User;
 import edu.skku.grabtable.review.domain.ReviewPlatform;
 import edu.skku.grabtable.review.domain.request.ReviewRequest;
 import edu.skku.grabtable.review.domain.request.ReviewUpdateRequest;
 import edu.skku.grabtable.review.domain.response.ReviewResponse;
 import edu.skku.grabtable.review.service.ReviewService;
+import edu.skku.grabtable.user.domain.User;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -103,7 +103,7 @@ class ReviewControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andExpect(status().isOk());
+                .andExpect(status().isCreated());
 
         //then
         Mockito.verify(reviewService).upload(ArgumentMatchers.any(), ArgumentMatchers.any());
@@ -147,7 +147,7 @@ class ReviewControllerTest extends ControllerTest {
         //when
         mockMvc.perform(MockMvcRequestBuilders.delete("/v1/reviews/{reviewId}", "1"))
                 .andDo(print())
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
 
         //then
         Mockito.verify(reviewService).delete(

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/user/controller/UserControllerTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/user/controller/UserControllerTest.java
@@ -51,7 +51,7 @@ public class UserControllerTest extends ControllerTest {
                 .thenReturn(user);
 
         //when
-        MvcResult result = mockMvc.perform(get("/v1/user/me")
+        MvcResult result = mockMvc.perform(get("/v1/users/me")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, "access-token")
                         .cookie(new Cookie("refresh-token", "refresh-token")))
@@ -75,7 +75,7 @@ public class UserControllerTest extends ControllerTest {
         UserUpdateRequest userUpdateRequest = new UserUpdateRequest("url", "username", "email", "phone");
 
         //when
-        mockMvc.perform(patch("/v1/user")
+        mockMvc.perform(patch("/v1/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(userUpdateRequest)))
                 .andExpect(status().isOk())

--- a/frontend/grabtable/src/components/CustomAvator.tsx
+++ b/frontend/grabtable/src/components/CustomAvator.tsx
@@ -17,7 +17,7 @@ export default function CustomAvatar() {
         return
       }
 
-      const response = await fetch(`${BASE_API_URL}/v1/user/me`, {
+      const response = await fetch(`${BASE_API_URL}/v1/users/me`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
### Type of Issue

<!-- 
이슈 번호와 간단한 설명을 적어주세요. 
resolve #<이슈번호> 넣으면 PR close시 자동으로 이슈도 close 됩니다.
ex. resolve #1
-->

resolve #128

### Key Change

- `src/test/java/edu/skku/grabtable/query/count`에서 api endpoint 별로 JPA가 쿼리를 몇 번 생성하는지 확인 가능합니다.

<!-- 핵심 변화를 나열해주세요. -->