### PR TITLE
Fix(be,fe): SSE 종료 이벤트 추가

### DIFF
--- a/backend/grabtable/src/main/java/edu/skku/grabtable/common/exception/ExceptionCode.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/common/exception/ExceptionCode.java
@@ -13,6 +13,7 @@ public enum ExceptionCode {
     NOT_FOUND_RESERVATION_ID(1004, "요청 ID에 해당하는 예약이 존재하지 않습니다."),
     NOT_FOUND_MENU_ID(1005, "요청 ID에 해당하는 메뉴가 존재하지 않습니다."),
     NOT_FOUND_CART_ID(1006, "요청 ID에 해당하는 장바구니 상품이 존재하지 않습니다."),
+    NOT_FOUND_LAST_RECENT_CONFIRMED_RESERVATION(1007, "가장 최근에 확정된 예약이 존재하지 않습니다."),
 
     UNABLE_TO_GET_USER_INFO(2001, "소셜 로그인 공급자로부터 유저 정보를 받아올 수 없습니다."),
     UNABLE_TO_GET_ACCESS_TOKEN(2002, "소셜 로그인 공급자로부터 인증 토큰을 받아올 수 없습니다."),

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/aop/ReservationAspect.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/aop/ReservationAspect.java
@@ -50,7 +50,18 @@ public class ReservationAspect {
         Object[] args = joinPoint.getArgs();
         for (Object arg : args) {
             if (arg instanceof User user) {
-                reservationService.send(user.getId());
+                reservationService.sendUpdateEvent(user.getId());
+                break;
+            }
+        }
+    }
+
+    @AfterReturning("reservationDestroyMethods()")
+    public void sendFinishEvent(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof User user) {
+                reservationService.sendFinishEvent(user.getId());
                 break;
             }
         }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/aop/ReservationAspect.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/aop/ReservationAspect.java
@@ -22,30 +22,31 @@ public class ReservationAspect {
             "execution(* edu.skku.grabtable.cart.controller.CartController.addCartInSharedOrder(..)) || " +
             "execution(* edu.skku.grabtable.cart.controller.CartController.updateCartInSharedOrder(..)) || " +
             "execution(* edu.skku.grabtable.cart.controller.CartController.deleteCartInSharedOrder(..))")
-    public void cartControllerUpdateMethods() {
+    public void cartUpdateMethods() {
     }
 
-    @Pointcut("execution(* edu.skku.grabtable.reservation.controller.ReservationController.join(..))")
-    public void reservationControllerUpdateMethods() {
+    @Pointcut("execution(* edu.skku.grabtable.reservation.controller.ReservationController.join(..)) || " +
+            "execution(* edu.skku.grabtable.reservation.service.ReservationService.leaveFromReservation(..))")
+    public void reservationUpdateMethods() {
     }
 
     @Pointcut("execution(* edu.skku.grabtable.reservation.controller.ReservationController.confirm(..)) || " +
-            "execution(* edu.skku.grabtable.reservation.controller.ReservationController.cancelReservation(..))")
+            "execution(* edu.skku.grabtable.reservation.service.ReservationService.destroyReservation(..))")
     public void reservationDestroyMethods() {
     }
 
     @Pointcut("execution(* edu.skku.grabtable.order.controller.OrderController.processPayment(..))")
-    public void orderControllerUpdateMethods() {
+    public void orderUpdateMethods() {
     }
 
     @Pointcut("execution(* edu.skku.grabtable.order.controller.SharedOrderController.processPayment(..))")
-    public void sharedOrderControllerUpdateMethods() {
+    public void sharedOrderUpdateMethods() {
 
     }
 
-    @AfterReturning("cartControllerUpdateMethods() || reservationControllerUpdateMethods() || "
-            + "orderControllerUpdateMethods() || sharedOrderControllerUpdateMethods()")
-    public void sendReservationEvent(JoinPoint joinPoint) {
+    @AfterReturning("cartUpdateMethods() || reservationUpdateMethods() || "
+            + "orderUpdateMethods() || sharedOrderUpdateMethods()")
+    public void sendUpdateEvent(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
         for (Object arg : args) {
             if (arg instanceof User user) {

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/domain/event/ReservationFinishEvent.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/domain/event/ReservationFinishEvent.java
@@ -1,0 +1,12 @@
+package edu.skku.grabtable.reservation.domain.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReservationFinishEvent {
+    private Long reservationId;
+}

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/domain/event/ReservationUpdateEvent.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/domain/event/ReservationUpdateEvent.java
@@ -1,0 +1,13 @@
+package edu.skku.grabtable.reservation.domain.event;
+
+import edu.skku.grabtable.reservation.domain.response.ReservationDetailResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReservationUpdateEvent {
+    private ReservationDetailResponse details;
+}

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/repository/ReservationRepository.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/repository/ReservationRepository.java
@@ -28,6 +28,17 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             """)
     Optional<Reservation> findOngoingReservationByUser(User user);
 
+    @Query("""
+                SELECT r
+                FROM Reservation r
+                WHERE (r.host.id = :userId
+                OR :userId IN (SELECT i.id FROM r.invitees i))
+                AND r.status = 'CONFIRMED'
+                ORDER BY r.lastModifiedAt DESC
+                LIMIT 1
+            """)
+    Optional<Reservation> findLastRecentlyConfirmedReservationByUserId(Long userId);
+
     Optional<Reservation> findByHostId(Long userId);
 
     Optional<Reservation> findByInviteCode(String inviteCode);

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/service/ReservationService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/service/ReservationService.java
@@ -267,12 +267,12 @@ public class ReservationService {
         });
     }
 
-    private ReservationDetailResponse serialize(Message message) {
+    private Object deserialize(Message message) {
         try {
             return objectMapper.readValue(message.getBody(),
-                    ReservationDetailResponse.class);
+                    Object.class);
         } catch (IOException e) {
-            //TODO
+            log.error("Redis Message Bytes 역직렬화 실패 = {}", e.getMessage());
             throw new RuntimeException(e);
         }
     }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/service/ReservationService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/service/ReservationService.java
@@ -210,7 +210,7 @@ public class ReservationService {
                 .toList();
     }
 
-    /* Server-side Event 처리 */
+    /* Server-sent Event 처리 */
 
     public void sendUpdateEvent(Long userId) {
         User user = userRepository.findById(userId)
@@ -221,9 +221,8 @@ public class ReservationService {
     }
 
     public void sendFinishEvent(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_USER_ID));
-        ReservationDetailResponse reservation = findOngoingReservationByUser(user);
+        Reservation reservation = reservationRepository.findLastRecentlyConfirmedReservationByUserId(userId)
+                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_LAST_RECENT_CONFIRMED_RESERVATION));
         ReservationFinishEvent reservationFinishEvent = new ReservationFinishEvent(reservation.getId());
         redisTemplate.convertAndSend(getChannelName(reservation.getId()), reservationFinishEvent);
     }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/service/ReservationService.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/reservation/service/ReservationService.java
@@ -292,10 +292,25 @@ public class ReservationService {
 
     private void sendToClient(SseEmitter emitter, Long userId, Object data) {
         try {
+            ReservationUpdateEvent reservationUpdateEvent = objectMapper.convertValue(data,
+                    ReservationUpdateEvent.class);
             emitter.send(SseEmitter.event()
                     .id(userId.toString())
-                    .name("reservation")
-                    .data(data));
+                    .name("reservationUpdate")
+                    .data(reservationUpdateEvent, MediaType.APPLICATION_JSON));
+        } catch (IllegalArgumentException ignored) {
+        } catch (IOException e) {
+            sseEmitterRepository.deleteById(userId);
+        }
+
+        try {
+            ReservationFinishEvent reservationFinishEvent = objectMapper.convertValue(data,
+                    ReservationFinishEvent.class);
+            emitter.send(SseEmitter.event()
+                    .id(userId.toString())
+                    .name("reservationFinish")
+                    .data(reservationFinishEvent, MediaType.APPLICATION_JSON));
+        } catch (IllegalArgumentException ignored) {
         } catch (IOException e) {
             sseEmitterRepository.deleteById(userId);
         }

--- a/backend/grabtable/src/main/java/edu/skku/grabtable/sse/repository/SseEmitterInMemoryRepository.java
+++ b/backend/grabtable/src/main/java/edu/skku/grabtable/sse/repository/SseEmitterInMemoryRepository.java
@@ -1,6 +1,7 @@
 package edu.skku.grabtable.sse.repository;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -17,8 +18,8 @@ public class SseEmitterInMemoryRepository {
         userEmitters.put(userId, emitter);
     }
 
-    public SseEmitter findById(Long userId) {
-        return userEmitters.getOrDefault(userId, null);
+    public Optional<SseEmitter> findById(Long userId) {
+        return Optional.ofNullable(userEmitters.get(userId));
     }
 
     public void deleteById(Long userId) {

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/integration/ReservationIntegrationTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/integration/ReservationIntegrationTest.java
@@ -270,4 +270,56 @@ public class ReservationIntegrationTest {
                 .hasMessageContaining(ExceptionCode.UNPAID_AMOUNT_EXIST.getMessage());
     }
 
+    // TODO invitee - reservation 연관관계 수정 후 테스트
+//    @Test
+//    @DisplayName("가장 최근에 확정한 예약을 조회할 수 있다.")
+//    void read_last_recently_confirmed_reservation() {
+//        //given
+//        User host = User.builder()
+//                .username("host")
+//                .build();
+//
+//        User userA = User.builder()
+//                .username("userA")
+//                .build();
+//
+//        Store store = Store.builder()
+//                .storeName("storeA")
+//                .build();
+//
+//        int menuPrice = 1000;
+//
+//        Menu menuA = Menu.builder()
+//                .store(store)
+//                .menuName("menuA")
+//                .price(menuPrice)
+//                .build();
+//
+//        userRepository.save(host);
+//        userRepository.save(userA);
+//        storeRepository.save(store);
+//        menuRepository.save(menuA);
+//
+//        reservationService.createNewReservation(host, store.getId());
+//        String inviteCode = reservationService.findOngoingReservationByUser(host).getInviteCode();
+//        reservationService.joinExistingReservation(userA, inviteCode);
+//
+//        cartService.createCart(host, menuA.getId(), 1);
+//        cartService.createCart(userA, menuA.getId(), 1);
+//
+//        orderService.processPayment(host, new PaymentRequest("1", menuPrice));
+//        orderService.processPayment(userA, new PaymentRequest("1", menuPrice));
+//
+//        reservationService.confirmCurrentReservation(host);
+//
+//        //when
+//        Reservation hostLastConfirmed = reservationRepository.findLastRecentlyConfirmedReservationByUserId(host.getId())
+//                .orElseThrow();
+//        Reservation userALastConfirmed = reservationRepository.findLastRecentlyConfirmedReservationByUserId(
+//                userA.getId()).orElseThrow();
+//
+//        //then
+//        assertThat(hostLastConfirmed).isEqualTo(userALastConfirmed);
+//    }
+
 }

--- a/backend/grabtable/src/test/java/edu/skku/grabtable/sse/repository/SseEmitterInMemoryRepositoryTest.java
+++ b/backend/grabtable/src/test/java/edu/skku/grabtable/sse/repository/SseEmitterInMemoryRepositoryTest.java
@@ -2,6 +2,7 @@ package edu.skku.grabtable.sse.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,10 +25,10 @@ class SseEmitterInMemoryRepositoryTest {
 
         //when
         sseEmitterInMemoryRepository.save(userId);
-        SseEmitter emitter = sseEmitterInMemoryRepository.findById(userId);
+        Optional<SseEmitter> emitter = sseEmitterInMemoryRepository.findById(userId);
 
         //then
-        assertThat(emitter).isNotNull();
+        assertThat(emitter.isPresent()).isTrue();
 
     }
 
@@ -42,7 +43,7 @@ class SseEmitterInMemoryRepositoryTest {
         sseEmitterInMemoryRepository.deleteById(userId);
 
         //then
-        SseEmitter emitter = sseEmitterInMemoryRepository.findById(userId);
-        assertThat(emitter).isNull();
+        Optional<SseEmitter> emitter = sseEmitterInMemoryRepository.findById(userId);
+        assertThat(emitter.isEmpty()).isTrue();
     }
 }

--- a/frontend/grabtable/src/app/restaurants/[id]/page.tsx
+++ b/frontend/grabtable/src/app/restaurants/[id]/page.tsx
@@ -53,7 +53,7 @@ export default function Restaurant() {
   const fetchReview = async () => {
     const response = await getStoreReviews(storeId)
     const data = await response.json()
-    setReviews(data.slice(0, 10))
+    setReviews(data.values)
   }
 
   useEffect(() => {

--- a/frontend/grabtable/src/components/OrderCard.tsx
+++ b/frontend/grabtable/src/components/OrderCard.tsx
@@ -165,13 +165,6 @@ export default function OrderCard({
         })
         return
       }
-
-      toast({
-        title: 'Confirmed',
-        description: 'Enjoy!',
-        duration: 1000,
-      })
-      router.push('/')
     })
   }
 


### PR DESCRIPTION
### Type of Issue

<!-- 
이슈 번호와 간단한 설명을 적어주세요. 
resolve #<이슈번호> 넣으면 PR close시 자동으로 이슈도 close 됩니다.
ex. resolve #1
-->

resolve #149 

### Key Change

- 이제 호스트가 예약을 종료하면 예약 내 모든 참여자에게 `ReservationFinishEvent`가 전달됩니다.
- 해당 이벤트를 수신한 참여자들은 toast 메시지로 예약이 호스트에 의해 종료되었음을 안내받고, 홈 페이지로 리다이렉션됩니다.
- 기존 예약을 갱신하기 위한 메시지가 이제 다른 이벤트 형식으로 전달됩니다.
- `ReservationDetailResponse`를 한 번 래핑한 `ReservationUpdateEvent`로 전달됩니다.




- `ReservationFinishEvent`를 전달할 때, 예약의 상태는 `ongoing`에서 `confirm`으로 전환되어 `ReservationService.findOngoingReservationByUser` 메소드에서 예외가 발생합니다.
    - 해당 메소드 대신 `ReservationRepository.findLastRecentlyConfirmedReservationByUserId`을 사용해 가장 최근에 확정된 예약 ID 채널로 종료 이벤트를 전송합니다.
    - 하지만 아직 호스트를 제외한 참가자들은 정상적인 종료 메시지를 받을 수 없습니다.
    - 이유는 다음과 같습니다.
    -  `ReservationRepository.findLastRecentlyConfirmedReservationByUserId` 는 다음과 같은 쿼리입니다.
 
```
SELECT r
FROM Reservation r
WHERE (r.host.id = :userId
OR :userId IN (SELECT i.id FROM r.invitees i))
AND r.status = 'CONFIRMED'
ORDER BY r.lastModifiedAt DESC
LIMIT 1
```
- 그리고 `ReservationService.confirmCurrentReservation()`은 `User(Invitee)` - `Reservation` 연관관계를 끊는 로직이 존재합니다.

```
public void confirmCurrentReservation(User user) {
    ...
    //invitee들의 예약 연관관계 해제
    List<User> invitees = userRepository.findByInvitedReservation(reservation);
    for (User invitee : invitees) {
        invitee.clearReservation();
    }
}
```
- 참가자들이 정상적인 종료 메시지를 받기 위해서는 `Reservation`이 확정 상태가 된 이후에도 참여자들의 ID 정보를 계속 갖고 있어야 합니다.
- 이를 가능하게 하려면 `Invitees` - `Reservation` 연관관계를 수정해야 합니다. (`InvitedReservation` 중간 테이블이 필요합니다.)
- 이 문제는 다음 PR에서 수정하도록 하겠습니다.
<!-- 핵심 변화를 나열해주세요. -->